### PR TITLE
fix a race condition between dragonfly and gophertunnel

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -272,7 +272,6 @@ func (conn *Conn) DoSpawnContext(ctx context.Context) error {
 	if !conn.gameDataReceived.Load() {
 		panic("(*Conn).DoSpawn must only be called on Dialer connections")
 	}
-	conn.waitingForSpawn.Store(true)
 
 	select {
 	case <-conn.close:
@@ -1108,7 +1107,7 @@ func (conn *Conn) handleStartGame(pk *packet.StartGame) error {
 	}
 
 	conn.loggedIn = true
-
+	conn.waitingForSpawn.Store(true)
 	conn.expect(packet.IDChunkRadiusUpdated, packet.IDPlayStatus)
 	_ = conn.WritePacket(&packet.RequestChunkRadius{ChunkRadius: int32(conn.chunkRadius)})
 	return nil


### PR DESCRIPTION
Fixes a race condition between Dragonfly (server) and Gophertunnel (client) where the connection sequence and spawn sequence happen too fast that Gophertunnel is stuck in a waiting state. This PR should fix that issue.

See [this message](https://discord.com/channels/623638955262345216/637335508166377513/873671655229104188) for more info about this bug.