### PR TITLE
Add extra documentation for the new NPC dialogue protocol

### DIFF
--- a/minecraft/protocol/packet/npc_dialogue.go
+++ b/minecraft/protocol/packet/npc_dialogue.go
@@ -16,8 +16,11 @@ type NPCDialogue struct {
 	// Dialogue is the text that the client should see.
 	Dialogue string
 	// SceneName is the scene the data was pulled from for the client.
+	// Note setting this to "" or a empty string will result in the client using the last / default scene json
+	// More info can be found at https://docs.microsoft.com/en-us/minecraft/creator/documents/npcdialogue
 	SceneName string
-	// NPCName is the name of the NPC to be displayed to the client.
+	// NPCName is the name of the NPC to be displayed to the client
+	// Note this isn't the name displayed as the nametag or in the ui, but seems to be never used
 	NPCName string
 	// ActionJSON is the JSON string of the buttons/actions the server can perform.
 	ActionJSON string

--- a/minecraft/protocol/packet/npc_request.go
+++ b/minecraft/protocol/packet/npc_request.go
@@ -3,12 +3,25 @@ package packet
 import "github.com/sandertv/gophertunnel/minecraft/protocol"
 
 const (
+	// CommandString is used to store a json array of json objects representing buttons.
 	NPCRequestActionSetActions = iota
+	// ActionType is used to store the index of the button clicked
+	// The behaviour of handling this can be different so that we either just handle the action now
+	// Or store it and execute it when the ExecuteClosingCommands is called.
 	NPCRequestActionExecuteAction
+	// ExecuteClosingCommands is used for executing commands (vanilla) or a callback based on when the actual window is closed or when the buttons type is closed.
 	NPCRequestActionExecuteClosingCommands
+	// SetName sets the name of the given NPC
+	// The name is stored in the CommandString and should be used to set the nameTag of the given entity
 	NPCRequestActionSetName
+	// SetSkin sets the current skin of the NPC
+	// This works off of skin index's usually in packs, but as far as I know this doesn't work on servers.
+	// The skin index is stored in the CommandString field
 	NPCRequestActionSetSkin
+	// SetInteractText sets the content (in the nbt data of the entity) to a string
+	// This new text is stored in the CommandString field
 	NPCRequestActionSetInteractText
+	// ExecuteOpeningCommands executes a command thats type is set to open or is forced to by the server!
 	NPCRequestActionExecuteOpeningCommands
 )
 
@@ -24,10 +37,12 @@ type NPCRequest struct {
 	RequestType byte
 	// CommandString is the command string set in the NPC. It may consist of multiple commands, depending on
 	// what the player set in it.
+	// Note this depends on the window as SetActions uses this as a json array of buttons.
 	CommandString string
-	// ActionType is the type of the action to execute.
+	// ActionType is the index of the given button selected
+	// Note when this is called we shouldn't run given buttons code as a dialogue isn't submitted until ExecuteClosingCommands is called. 
 	ActionType byte
-	// SceneName is the name of the scene.
+	// SceneName is the name of the scene this is usually just "".
 	SceneName string
 }
 


### PR DESCRIPTION
# Overview
Added extra documentation for NpcRequest and NpcDialogue.

This data has been tested by myself and has been proven to work and be mostly effective.

Somethings seem to be not supported as of now like SetSkin.

Other than that this PR greatly improves the documentation on the npc protocol

## NpcRequest

- All constants are now provided with a comment describing there use in manual npc handling or in the vanilla form editor mode.

- All packet fields now have extended data

## NpcDialogue

- Added extra info on scene names and documentation links for NPC dialogues.

- Also provided information on how the client handles certain fields like NPCName.