### PR TITLE
Fix PlayerDiedEventData

### DIFF
--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -119,15 +119,7 @@ type PlayerDiedEventData struct {
 }
 
 // Marshal ...
-func (p *PlayerDiedEventData) Marshal(w *Writer) {
-	w.Varint32(&p.AttackerEntityID)
-	w.Varint32(&p.AttackerVariant)
-	w.Varint32(&p.EntityDamageCause)
-	w.Bool(&p.InRaid)
-}
-
-// Unmarshal ...
-func (p *PlayerDiedEventData) Unmarshal(r *Reader) {
+func (p *PlayerDiedEventData) Marshal(r IO) {
 	r.Varint32(&p.AttackerEntityID)
 	r.Varint32(&p.AttackerVariant)
 	r.Varint32(&p.EntityDamageCause)

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -110,14 +110,28 @@ func (c *CauldronUsedEventData) Marshal(r IO) {
 type PlayerDiedEventData struct {
 	// AttackerEntityID ...
 	AttackerEntityID int32
+	// AttackerVariant ...
+	AttackerVariant int32
 	// EntityDamageCause ...
 	EntityDamageCause int32
+	// InRaid ...
+	InRaid bool
 }
 
 // Marshal ...
-func (p *PlayerDiedEventData) Marshal(r IO) {
+func (p *PlayerDiedEventData) Marshal(w *Writer) {
+	w.Varint32(&p.AttackerEntityID)
+	w.Varint32(&p.AttackerVariant)
+	w.Varint32(&p.EntityDamageCause)
+	w.Bool(&p.InRaid)
+}
+
+// Unmarshal ...
+func (p *PlayerDiedEventData) Unmarshal(r *Reader) {
 	r.Varint32(&p.AttackerEntityID)
+	r.Varint32(&p.AttackerVariant)
 	r.Varint32(&p.EntityDamageCause)
+	r.Bool(&p.InRaid)
 }
 
 // BossKilledEventData is the event data sent when a boss dies.


### PR DESCRIPTION
I use gophertunnel as a proxy server. When a player dies, an error message arrives (*packet.Event: 2 unread bytes left: 0x0a00). I found a mismatch of PlayerDiedEventData with the original protocol. After the correction, no errors occur.

https://github.com/CloudburstMC/Protocol/blob/f92336f2433875a1116c103dc0100b92cd260e2b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/event/PlayerDiedEventData.java