### PR TITLE
fix waxing event panicing

### DIFF
--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -411,3 +411,15 @@ type WaxedOrUnwaxedCopperEventData struct {
 func (w *WaxedOrUnwaxedCopperEventData) Marshal(r IO) {
 	r.Uint16(&w.Type)
 }
+
+// SneakCloseToSculkSensorEventData is an event sent by the server when a player sneaks close to an sculk block.
+type SneakCloseToSculkSensorEventData struct{}
+
+// Marshal ...
+func (u *SneakCloseToSculkSensorEventData) Marshal(r IO) {}
+
+// UnknownEventData is an unimplemented event
+type UnknownEventData struct{}
+
+// Marshal ...
+func (u *UnknownEventData) Marshal(r IO) {}

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -390,3 +390,24 @@ type ExtractHoneyEventData struct{}
 
 // Marshal ...
 func (*ExtractHoneyEventData) Marshal(IO) {}
+
+const (
+	WaxNotOxidised   = uint16(0xa609)
+	WaxExposed       = uint16(0xa809)
+	WaxWeathered     = uint16(0xaa09)
+	WaxOxidised      = uint16(0xac09)
+	UnWaxNotOxidised = uint16(0xae09)
+	UnWaxExposed     = uint16(0xb009)
+	UnWaxWeathered   = uint16(0xb209)
+	UnWaxOxidised    = uint16(0xfa0a)
+)
+
+// WaxedOrUnwaxedCopperEventData is an event sent by the server when a copper block is waxed or unwaxed.
+type WaxedOrUnwaxedCopperEventData struct {
+	Type uint16
+}
+
+// Marshal ...
+func (w *WaxedOrUnwaxedCopperEventData) Marshal(r IO) {
+	r.Uint16(&w.Type)
+}

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -417,9 +417,3 @@ type SneakCloseToSculkSensorEventData struct{}
 
 // Marshal ...
 func (u *SneakCloseToSculkSensorEventData) Marshal(r IO) {}
-
-// UnknownEventData is an unimplemented event
-type UnknownEventData struct{}
-
-// Marshal ...
-func (u *UnknownEventData) Marshal(r IO) {}

--- a/minecraft/protocol/packet/event.go
+++ b/minecraft/protocol/packet/event.go
@@ -122,8 +122,6 @@ func (pk *Event) Unmarshal(r *protocol.Reader) {
 		pk.EventData = &protocol.WaxedOrUnwaxedCopperEventData{}
 	case EventTypeSneakCloseToSculkSensor:
 		pk.EventData = &protocol.SneakCloseToSculkSensorEventData{}
-	default:
-		pk.EventData = &protocol.UnknownEventData{}
 	}
 
 	pk.EventData.Marshal(r)

--- a/minecraft/protocol/packet/event.go
+++ b/minecraft/protocol/packet/event.go
@@ -120,6 +120,10 @@ func (pk *Event) Unmarshal(r *protocol.Reader) {
 		pk.EventData = &protocol.ExtractHoneyEventData{}
 	case EventTypePlayerWaxedOrUnwaxedCopper:
 		pk.EventData = &protocol.WaxedOrUnwaxedCopperEventData{}
+	case EventTypeSneakCloseToSculkSensor:
+		pk.EventData = &protocol.SneakCloseToSculkSensorEventData{}
+	default:
+		pk.EventData = &protocol.UnknownEventData{}
 	}
 
 	pk.EventData.Marshal(r)

--- a/minecraft/protocol/packet/event.go
+++ b/minecraft/protocol/packet/event.go
@@ -118,6 +118,8 @@ func (pk *Event) Unmarshal(r *protocol.Reader) {
 		pk.EventData = &protocol.MovementCorrectedEventData{}
 	case EventTypeExtractHoney:
 		pk.EventData = &protocol.ExtractHoneyEventData{}
+	case EventTypePlayerWaxedOrUnwaxedCopper:
+		pk.EventData = &protocol.WaxedOrUnwaxedCopperEventData{}
 	}
 
 	pk.EventData.Marshal(r)

--- a/minecraft/protocol/packet/level_event.go
+++ b/minecraft/protocol/packet/level_event.go
@@ -76,9 +76,9 @@ const (
 	LevelEventParticlesVibrationSignal     = 2027
 	LevelEventParticlesDripstoneDrip       = 2028
 	LevelEventParticlesFizzEffect          = 2029
-	LevelEventWaxOn                        = 2030
-	LevelEventWaxOff                       = 2031
-	LevelEventScrape                       = 2032
+	LevelEventParticlesWaxOn               = 2030
+	LevelEventParticlesWaxOff              = 2031
+	LevelEventParticlesScrape              = 2032
 	LevelEventParticlesElectricSpark       = 2033
 	LevelEventParticleTurtleEgg            = 2034
 	LevelEventParticleSculkShriek          = 2035

--- a/minecraft/protocol/packet/level_event.go
+++ b/minecraft/protocol/packet/level_event.go
@@ -76,9 +76,9 @@ const (
 	LevelEventParticlesVibrationSignal     = 2027
 	LevelEventParticlesDripstoneDrip       = 2028
 	LevelEventParticlesFizzEffect          = 2029
-	LevelEventParticlesWaxOn               = 2030
-	LevelEventParticlesWaxOff              = 2031
-	LevelEventParticlesScrape              = 2032
+	LevelEventWaxOn                        = 2030
+	LevelEventWaxOff                       = 2031
+	LevelEventScrape                       = 2032
 	LevelEventParticlesElectricSpark       = 2033
 	LevelEventParticleTurtleEgg            = 2034
 	LevelEventParticleSculkShriek          = 2035


### PR DESCRIPTION
Fixes a panic because of the EventData for waxing not being in the switch,
also makes the names of the events for waxing consistent with the rest.