### PR TITLE
reverse defaultclientdata and defaultidentitydata

### DIFF
--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -180,8 +180,8 @@ func (d Dialer) DialContext(ctx context.Context, network, address string) (conn 
 	// Disable the batch packet limit so that the server can send packets as often as it wants to.
 	conn.dec.DisableBatchPacketLimit()
 
-	defaultClientData(address, conn.identityData.DisplayName, &conn.clientData)
 	defaultIdentityData(&conn.identityData)
+	defaultClientData(address, conn.identityData.DisplayName, &conn.clientData)
 
 	var request []byte
 	if d.TokenSource == nil {


### PR DESCRIPTION
Client data relies on identity data, but the identity data is being set after

so if the user passes a blank DisplayName in then identity data would set it to "Steve", but this would happen after setting the client data, leading to ThirdPartyName and DisplayName mismatching