### PR TITLE
Fix incorrect documentation for client_item_start_cooldown

### DIFF
--- a/minecraft/protocol/packet/client_start_item_cooldown.go
+++ b/minecraft/protocol/packet/client_start_item_cooldown.go
@@ -4,8 +4,7 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 )
 
-// ClientStartItemCooldown is sent by the client to the server to initiate a cooldown on an item. The purpose of this
-// packet isn't entirely clear.
+// ClientStartItemCooldown is sent by the server to the client to initiate a cooldown on an item.
 type ClientStartItemCooldown struct {
 	// Category is the category of the item to start the cooldown on.
 	Category string


### PR DESCRIPTION
client_start_item_cooldown is sent by server to tell the client to start cooldown of given item.

Here is the example case I've implemented in PocketMine(Edited Ender Pearl's cooldown to 15 seconds):


https://user-images.githubusercontent.com/32565818/218313575-11f26518-834e-49c7-8635-3ed7bf0d8c20.mp4

