### PR TITLE
Correct the invalid packets setting.

### DIFF
--- a/minecraft/packet.go
+++ b/minecraft/packet.go
@@ -46,7 +46,7 @@ func (p *packetData) decode(conn *Conn) (pks []packet.Packet, err error) {
 		if err == nil {
 			return
 		}
-		if _, ok := err.(unknownPacketError); ok || conn.disconnectOnInvalidPacket {
+		if _, ok := err.(unknownPacketError); ok && conn.disconnectOnInvalidPacket {
 			_ = conn.Close()
 		}
 	}()


### PR DESCRIPTION
This typo caused disconnections when receiving invalid packets, whether you had it enabled or not.