### PR TITLE
Correct the unknown packets setting.

### DIFF
--- a/minecraft/packet.go
+++ b/minecraft/packet.go
@@ -46,7 +46,7 @@ func (p *packetData) decode(conn *Conn) (pks []packet.Packet, err error) {
 		if err == nil {
 			return
 		}
-		if _, ok := err.(unknownPacketError); ok && conn.disconnectOnInvalidPacket {
+		if _, ok := err.(unknownPacketError); (ok && conn.disconnectOnUnknownPacket) || conn.disconnectOnInvalidPacket {
 			_ = conn.Close()
 		}
 	}()

--- a/minecraft/packet.go
+++ b/minecraft/packet.go
@@ -46,7 +46,7 @@ func (p *packetData) decode(conn *Conn) (pks []packet.Packet, err error) {
 		if err == nil {
 			return
 		}
-		if _, ok := err.(unknownPacketError); (ok && conn.disconnectOnUnknownPacket) || conn.disconnectOnInvalidPacket {
+		if _, ok := err.(unknownPacketError); (ok && conn.disconnectOnUnknownPacket) || (!ok && conn.disconnectOnInvalidPacket) {
 			_ = conn.Close()
 		}
 	}()


### PR DESCRIPTION
This typo caused disconnections when receiving unknown packets, whether you had it enabled or not.