### PR TITLE
Actor Event is bidirectional

### DIFF
--- a/minecraft/protocol/packet/pool.go
+++ b/minecraft/protocol/packet/pool.go
@@ -266,6 +266,7 @@ func init() {
 		IDMovePlayer:                      func() Packet { return &MovePlayer{} },
 		IDPassengerJump:                   func() Packet { return &PassengerJump{} },
 		IDTickSync:                        func() Packet { return &TickSync{} },
+		IDActorEvent:                      func() Packet { return &ActorEvent{} },
 		IDInventoryTransaction:            func() Packet { return &InventoryTransaction{} },
 		IDMobEquipment:                    func() Packet { return &MobEquipment{} },
 		IDInteract:                        func() Packet { return &Interact{} },


### PR DESCRIPTION
It looks like the Actor Event Packet is bidirectional; I can confirm this from using the client, as well as from:
https://github.com/pmmp/BedrockProtocol/blob/master/src/ActorEventPacket.php#L20