### PR TITLE
Download resource packs from a URL, rename Compile methods

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -748,6 +748,13 @@ func (conn *Conn) handleClientToServerHandshake() error {
 	}
 	pk := &packet.ResourcePacksInfo{TexturePackRequired: conn.texturePacksRequired}
 	for _, pack := range conn.resourcePacks {
+		if pack.DownloadURL() != "" {
+			pk.PackURLs = append(pk.PackURLs, protocol.PackURL{
+				UUIDVersion: fmt.Sprintf("%s_%s", pack.UUID(), pack.Version()),
+				URL:         pack.DownloadURL(),
+			})
+		}
+
 		// If it has behaviours, add it to the behaviour pack list. If not, we add it to the texture packs
 		// list.
 		if pack.HasBehaviours() {
@@ -1123,7 +1130,7 @@ func (conn *Conn) handleResourcePackDataInfo(pk *packet.ResourcePackDataInfo) er
 			return
 		}
 		// First parse the resource pack from the total byte buffer we obtained.
-		newPack, err := resource.FromBytes(pack.buf.Bytes())
+		newPack, err := resource.Read(pack.buf)
 		if err != nil {
 			conn.log.Printf("invalid full resource pack data for UUID %v: %v\n", id, err)
 			return

--- a/minecraft/protocol/resource_pack.go
+++ b/minecraft/protocol/resource_pack.go
@@ -100,16 +100,16 @@ func (x *StackResourcePack) Marshal(r IO) {
 // PackURL represents a resource pack that is being served from a HTTP server rather than being sent over
 // the Minecraft protocol.
 type PackURL struct {
-	// UUID is the UUID of the resource pack. Each resource pack downloaded must have a different UUID in
-	// order for the client to be able to handle them properly.
-	UUID string
+	// UUIDVersion is a combination of the UUID and version of the resource pack in the format UUID_Version.
+	// The client will only attempt to download the resource pack if it does not already have it cached.
+	UUIDVersion string
 	// URL is the URL from which the resource pack is downloaded. This URL must serve a zip file containing
-	// a manifest.json file inside of another folder. The manifest cannot be in the root of the zip file.
+	// a manifest.json file inside another folder. The manifest cannot be in the root of the zip file.
 	URL string
 }
 
 // Marshal encodes/decodes a CDNURL.
 func (x *PackURL) Marshal(r IO) {
-	r.String(&x.UUID)
+	r.String(&x.UUIDVersion)
 	r.String(&x.URL)
 }

--- a/minecraft/resource/pack.go
+++ b/minecraft/resource/pack.go
@@ -45,9 +45,9 @@ func ReadPath(path string) (*Pack, error) {
 	return compile(path)
 }
 
-// ReadURL compiles a resource pack found at the URL passed. The resource pack must be a valid zip archive
-// where the manifest.json file is inside a subdirectory rather than the root itself. If the resource pack is
-// not a valid zip or there is no manifest.json file, an error is returned.
+// ReadURL downloads a resource pack found at the URL passed and compiles it. The resource pack must be a valid
+// zip archive where the manifest.json file is inside a subdirectory rather than the root itself. If the resource
+// pack is not a valid zip or there is no manifest.json file, an error is returned.
 func ReadURL(url string) (*Pack, error) {
 	resp, err := http.Get(url)
 	if err != nil {
@@ -61,7 +61,8 @@ func ReadURL(url string) (*Pack, error) {
 	if err != nil {
 		return nil, err
 	}
-	return pack.WithDownloadURL(url), nil
+	pack.downloadURL = url
+	return pack, nil
 }
 
 // MustReadPath compiles a resource pack found at the path passed. The resource pack must either be a zip
@@ -78,9 +79,9 @@ func MustReadPath(path string) *Pack {
 	return pack
 }
 
-// MustReadURL compiles a resource pack found at the URL passed. The resource pack must be a valid zip archive
-// where the manifest.json file is inside a subdirectory rather than the root itself. If the resource pack is
-// not a valid zip or there is no manifest.json file, an error is returned.
+// MustReadURL downloads a resource pack found at the URL passed and compiles it. The resource pack must be a valid
+// zip archive where the manifest.json file is inside a subdirectory rather than the root itself. If the resource
+// pack is not a valid zip or there is no manifest.json file, an error is returned.
 // Unlike ReadURL, MustReadURL does not return an error and panics if an error occurs instead.
 func MustReadURL(url string) *Pack {
 	pack, err := ReadURL(url)
@@ -188,13 +189,6 @@ func (pack *Pack) HasWorldTemplate() bool {
 // resource pack will be downloaded over RakNet rather than HTTP.
 func (pack *Pack) DownloadURL() string {
 	return pack.downloadURL
-}
-
-// WithDownloadURL creates a copy of the pack and sets the download URL to the URL provided, after which the new
-// Pack is returned.
-func (pack Pack) WithDownloadURL(url string) *Pack {
-	pack.downloadURL = url
-	return &pack
 }
 
 // Checksum returns the SHA256 checksum made from the full, compressed content of the resource pack archive.


### PR DESCRIPTION
Resource packs with a download URL will now send the URL in the `ResourcePacksInfo` packet.

A few breaking API changes have been made to the `minecraft/resource` package:
```diff
- resource.FromBytes([]byte) (*resource.Pack, error)
+ resource.Read(io.Reader) (*resource.Pack, error)

- resource.Compile(string) (*resource.Pack, error)
+ resource.ReadPath(string) (*resource.Pack, error)

- resource.MustCompile(string) *resource.Pack
+ resource.MustReadPath(string) *resource.Pack

+ resource.ReadURL(string) (*resource.Pack, error)
+ resource.MustReadURL(string) *resource.Pack
```

Two new functions have been added to the `resource.Pack` struct:
```diff
+ DownloadURL() string
+ WithDownloadURL(string) *resource.Pack
```