### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/minecraft/protocol/enchant.go
+++ b/minecraft/protocol/enchant.go
@@ -8,7 +8,7 @@ type EnchantmentOption struct {
 	// Enchantments holds the enchantments that will be applied to the item when this option is clicked.
 	Enchantments ItemEnchantments
 	// Name is a name that will be translated to the 'Standard Galactic Alphabet'
-	// (https://minecraft.gamepedia.com/Enchanting_Table#Standard_Galactic_Alphabet) client-side. The names
+	// (https://minecraft.wiki/w/Enchanting_Table#Standard_Galactic_Alphabet) client-side. The names
 	// generally have no meaning, such as:
 	// 'animal imbue range galvanize '
 	// 'bless inside creature shrink '

--- a/minecraft/protocol/packet/animate_entity.go
+++ b/minecraft/protocol/packet/animate_entity.go
@@ -8,7 +8,7 @@ import (
 // animation, or to activate a controller which can start a sequence of animations based on different
 // conditions specified in an animation controller.
 // Much of the documentation of this packet can be found at
-// https://minecraft.gamepedia.com/Bedrock_Edition_beta_animation_documentation.
+// https://learn.microsoft.com/en-us/minecraft/creator/reference/content/animationsreference
 type AnimateEntity struct {
 	// Animation is the name of a single animation to start playing.
 	Animation string

--- a/minecraft/protocol/packet/structure_block_update.go
+++ b/minecraft/protocol/packet/structure_block_update.go
@@ -29,7 +29,7 @@ type StructureBlockUpdate struct {
 	// used to export the structure to a file.
 	StructureName string
 	// DataField is the name of a function to run, usually used during natural generation. A description can
-	// be found here: https://minecraft.gamepedia.com/Structure_Block#Data.
+	// be found here: https://minecraft.wiki/w/Structure_Block#Data.
 	DataField string
 	// IncludePlayers specifies if the 'Include Players' toggle has been enabled, meaning players are also
 	// exported by the structure block.

--- a/minecraft/resource/manifest.go
+++ b/minecraft/resource/manifest.go
@@ -1,7 +1,7 @@
 package resource
 
 // Documentation on this may be found here:
-// https://minecraft.gamepedia.com/Bedrock_Edition_add-on_documentation
+// https://learn.microsoft.com/en-us/minecraft/creator/reference/content/addonsreference/examples/addonmanifest
 
 // Manifest contains all the basic information about the pack that Minecraft needs to identify it.
 type Manifest struct {


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates most wiki links to the new domain but also some links to the official bedrock development docs.