### PR TITLE
minecraft/nbt: Support network big endian

### DIFF
--- a/minecraft/nbt/decode.go
+++ b/minecraft/nbt/decode.go
@@ -468,7 +468,12 @@ func (d *Decoder) tag() (t tagType, tagName string, err error) {
 	if err != nil {
 		return 0, "", BufferOverrunError{Op: "ReadTag"}
 	}
-	if t = tagType(tagTypeByte); t != tagEnd {
+	t = tagType(tagTypeByte)
+	if _, ok := d.Encoding.(networkBigEndian); ok && t == tagStruct && d.depth == 0 {
+		// As of Minecraft Java 1.20.2, the name of the root compound tag is not written over the network.
+		return t, "", err
+	}
+	if t != tagEnd {
 		// Only read a tag name if the tag's type is not TAG_End.
 		tagName, err = d.Encoding.String(d.r)
 	}

--- a/minecraft/nbt/encode.go
+++ b/minecraft/nbt/encode.go
@@ -299,5 +299,9 @@ func (e *Encoder) writeTag(t tagType, tagName string) error {
 	if err := e.w.WriteByte(byte(t)); err != nil {
 		return err
 	}
+	if _, ok := e.Encoding.(networkBigEndian); ok && t == tagStruct && e.depth == 1 {
+		// As of Minecraft Java 1.20.2, the name of the root compound tag is not written over the network.
+		return nil
+	}
 	return e.Encoding.WriteString(e.w, tagName)
 }

--- a/minecraft/nbt/encoding.go
+++ b/minecraft/nbt/encoding.go
@@ -36,12 +36,18 @@ var (
 	// writing Minecraft (Bedrock Edition) world saves.
 	LittleEndian littleEndian
 
+	// NetworkBigEndian is a version of BigEndian introduced in 1.20.2 where the name of the root compound tag is
+	// not written. Similarly to BigEndian, it is only used on Minecraft Java Edition and generally used for NBT
+	// sent over the network.
+	NetworkBigEndian networkBigEndian
+
 	// BigEndian is the fixed size big endian implementation of NBT. It is the original implementation, and is
 	// used only on Minecraft Java Edition.
 	BigEndian bigEndian
 
 	_ Encoding = NetworkLittleEndian
 	_ Encoding = LittleEndian
+	_ Encoding = NetworkBigEndian
 	_ Encoding = BigEndian
 )
 
@@ -210,3 +216,5 @@ func (e networkLittleEndian) Int64Slice(r *offsetReader) ([]int64, error) {
 	}
 	return m, nil
 }
+
+type networkBigEndian struct{ bigEndian }


### PR DESCRIPTION
Support for 1.20.2's "network" big endian format, fixes #220 