### PR TITLE
minecraft/conn.go: Introduce `ReadBytes`

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -405,9 +405,25 @@ func (conn *Conn) Write(b []byte) (n int, err error) {
 	return len(b), nil
 }
 
+// ReadBytes reads a packet from the connection without decoding it directly.
+// For direct reading, consider using ReadPacket() which decodes the packet.
+func (conn *Conn) ReadBytes() ([]byte, error) {
+	if data, ok := conn.takeDeferredPacket(); ok {
+		return data.full, nil
+	}
+	select {
+	case <-conn.close:
+		return nil, conn.closeErr("read")
+	case <-conn.readDeadline:
+		return nil, conn.wrap(context.DeadlineExceeded, "read")
+	case data := <-conn.packets:
+		return data.full, nil
+	}
+}
+
 // Read reads a packet from the connection into the byte slice passed, provided the byte slice is big enough
 // to carry the full packet.
-// It is recommended to use ReadPacket() rather than Read() in cases where reading is done directly.
+// It is recommended to use ReadPacket() and ReadBytes() rather than Read() in cases where reading is done directly.
 func (conn *Conn) Read(b []byte) (n int, err error) {
 	if data, ok := conn.takeDeferredPacket(); ok {
 		if len(b) < len(data.full) {


### PR DESCRIPTION
This PR introduces `ReadBytes`, a method for efficiently reading packet payloads in `minecraft/conn.go`. This improvement is particularly useful for scenarios like proxies that forward data directly, where it eliminates unnecessary packet decoding overhead.