### PR TITLE
Update pong data

### DIFF
--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -188,7 +188,7 @@ func (listener *Listener) updatePongData() {
 	s := listener.status()
 	listener.listener.PongData([]byte(fmt.Sprintf("MCPE;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;",
 		s.ServerName, protocol.CurrentProtocol, protocol.CurrentVersion, s.PlayerCount, s.MaxPlayers,
-		listener.listener.ID(), listener.status().ServerSubName, "Creative", 1, listener.Addr().(*net.UDPAddr).Port, listener.Addr().(*net.UDPAddr).Port,
+		listener.listener.ID(), s.ServerSubName, "Creative", 1, listener.Addr().(*net.UDPAddr).Port, listener.Addr().(*net.UDPAddr).Port,
 		0,
 	)))
 }

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -186,9 +186,10 @@ func (listener *Listener) Close() error {
 // server name of the listener, provided the listener isn't currently hijacking the pong of another server.
 func (listener *Listener) updatePongData() {
 	s := listener.status()
-	listener.listener.PongData([]byte(fmt.Sprintf("MCPE;%v;%v;%v;%v;%v;%v;%s;%v;%v;%v;%v;",
+	listener.listener.PongData([]byte(fmt.Sprintf("MCPE;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;",
 		s.ServerName, protocol.CurrentProtocol, protocol.CurrentVersion, s.PlayerCount, s.MaxPlayers,
 		listener.listener.ID(), listener.status().ServerSubName, "Creative", 1, listener.Addr().(*net.UDPAddr).Port, listener.Addr().(*net.UDPAddr).Port,
+		0,
 	)))
 }
 

--- a/minecraft/server_status_provider.go
+++ b/minecraft/server_status_provider.go
@@ -126,7 +126,7 @@ func parsePongData(pong []byte) ServerStatus {
 		return ServerStatus{ServerName: "Invalid pong data"}
 	}
 	serverName := frag[1]
-	serverSubName := frag[6]
+	serverSubName := frag[7]
 	online, err := strconv.Atoi(frag[4])
 	if err != nil {
 		return ServerStatus{ServerName: "Invalid player count"}


### PR DESCRIPTION
This pr fixes the incorrect server subname index, and adds a 0 at the end of the pong data to match with BDS

https://github.com/PrismarineJS/bedrock-protocol/blob/84c5231b92df9f5f1a09b29a05e7abfed62f1c2b/src/server/advertisement.js#L34

pong data from a bds server
MCPE;Dedicated Server;685;1.21.0;0;10;9799519352691166920;Bedrock level;Survival;1;19133;19134;0;