### PR TITLE
Update pool.go To Fix Packet 75

### DIFF
--- a/minecraft/protocol/packet/pool.go
+++ b/minecraft/protocol/packet/pool.go
@@ -286,6 +286,7 @@ func init() {
 		IDMapInfoRequest:                  func() Packet { return &MapInfoRequest{} },
 		IDRequestChunkRadius:              func() Packet { return &RequestChunkRadius{} },
 		IDBossEvent:                       func() Packet { return &BossEvent{} },
+		IDShowCredits:                 	   func() Packet { return &ShowCredits{} },
 		IDCommandRequest:                  func() Packet { return &CommandRequest{} },
 		IDCommandBlockUpdate:              func() Packet { return &CommandBlockUpdate{} },
 		IDResourcePackChunkRequest:        func() Packet { return &ResourcePackChunkRequest{} },


### PR DESCRIPTION
When going from the end to the overworld you are prompted with the credits screen, this is sent from the server. However when a player skips the credits the player sends back the credits packet, which is currently not handled.

![image](https://github.com/user-attachments/assets/3d04dc87-68ea-4c86-b563-e3879e2d2fce)
