### PR TITLE
Fix in-proper depreciation message in `client_cheat_ability.go`

### DIFF
--- a/minecraft/protocol/packet/client_cheat_ability.go
+++ b/minecraft/protocol/packet/client_cheat_ability.go
@@ -4,8 +4,9 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 )
 
-// ClientCheatAbility functions the same as UpdateAbilities. It is unclear why these two are separated.
-// ClientCheatAbility is deprecated as of 1.20.10.
+// ClientCheatAbility functions the same as UpdateAbilities. It is unclear why these two were separated.
+//
+// Deprecated: ClientCheatAbility is deprecated as of 1.20.10.
 type ClientCheatAbility struct {
 	// AbilityData represents various data about the abilities of a player, such as ability layers or permissions.
 	AbilityData protocol.AbilityData


### PR DESCRIPTION
Properly Standerdise Deprecated noting to match GOLang standard.