### PR TITLE
Mark `FilterText` packet as deprecated in `filter_text.go`

### DIFF
--- a/minecraft/protocol/packet/filter_text.go
+++ b/minecraft/protocol/packet/filter_text.go
@@ -7,6 +7,8 @@ import (
 // FilterText is sent by the both the client and the server. The client sends the packet to the server to
 // allow the server to filter the text server-side. The server then responds with the same packet and the
 // safer version of the text.
+//
+// Deprecated: This packet was deprecated in unknown.
 type FilterText struct {
 	// Text is either the text from the client or the safer version of the text sent by the server.
 	Text string


### PR DESCRIPTION
Properly Standerdise Deprecated noting to match GOLang standard.

I don't know when this was deprecated tho.