### PR TITLE
Fix Depreciation messages in `photo_info_request.go`, `filter_text.go` & `client_cheat_ability.go`

### DIFF
--- a/minecraft/protocol/packet/client_cheat_ability.go
+++ b/minecraft/protocol/packet/client_cheat_ability.go
@@ -4,8 +4,9 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 )
 
-// ClientCheatAbility functions the same as UpdateAbilities. It is unclear why these two are separated.
-// ClientCheatAbility is deprecated as of 1.20.10.
+// ClientCheatAbility functions the same as UpdateAbilities. It is unclear why these two were separated.
+//
+// Deprecated: ClientCheatAbility is deprecated as of 1.20.10.
 type ClientCheatAbility struct {
 	// AbilityData represents various data about the abilities of a player, such as ability layers or permissions.
 	AbilityData protocol.AbilityData

--- a/minecraft/protocol/packet/filter_text.go
+++ b/minecraft/protocol/packet/filter_text.go
@@ -7,6 +7,8 @@ import (
 // FilterText is sent by the both the client and the server. The client sends the packet to the server to
 // allow the server to filter the text server-side. The server then responds with the same packet and the
 // safer version of the text.
+//
+// Deprecated: This packet was deprecated in unknown.
 type FilterText struct {
 	// Text is either the text from the client or the safer version of the text sent by the server.
 	Text string

--- a/minecraft/protocol/packet/photo_info_request.go
+++ b/minecraft/protocol/packet/photo_info_request.go
@@ -5,6 +5,8 @@ import (
 )
 
 // PhotoInfoRequest is sent by the client to request photo information from the server. This packet was deprecated in 1.19.80.
+//
+// Deprecated: This packet was deprecated in 1.19.80.
 type PhotoInfoRequest struct {
 	// PhotoID is the ID of the photo.
 	PhotoID int64

--- a/minecraft/protocol/packet/photo_info_request.go
+++ b/minecraft/protocol/packet/photo_info_request.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 )
 
-// PhotoInfoRequest is sent by the client to request photo information from the server. This packet was deprecated in 1.19.80.
+// PhotoInfoRequest is sent by the client to request photo information from the server.
 //
 // Deprecated: This packet was deprecated in 1.19.80.
 type PhotoInfoRequest struct {


### PR DESCRIPTION
Properly Standerdise Deprecated noting to match GOLang standard.