### PR TITLE
Fix Spelling Mistakes in `trim.go`

### DIFF
--- a/minecraft/protocol/trim.go
+++ b/minecraft/protocol/trim.go
@@ -1,11 +1,11 @@
 package protocol
 
-// TrimPattern represnets a pattern that can be applied to an armour pice in combination with a TrimMaterial.
+// TrimPattern represents a pattern that can be applied to an armour piece in combination with a TrimMaterial.
 type TrimPattern struct {
 	// ItemName is the identifier of the item that represents the pattern, for example
 	// 'minecraft:wayfinder_armor_trim_smithing_template'.
 	ItemName string
-	// PatternID is the identifier of the pattern, for example 'wayfinder'.
+	// PatternID is the identifier of the pattern, for example, 'wayfinder'.
 	PatternID string
 }
 
@@ -21,7 +21,7 @@ type TrimMaterial struct {
 	MaterialID string
 	// Colour is the colour code used for text formatting, for example '§j'.
 	Colour string
-	// ItemName is the identifier of the item that represents the material, for example 'minecraft:netherite_ingot'.
+	// ItemName is the identifier of the item that represents the material, for example, 'minecraft:netherite_ingot'.
 	ItemName string
 }
 


### PR DESCRIPTION
Fix spelling mistakes and add proper punctuation.