### PR TITLE
Update player_auth_input.go

### DIFF
--- a/minecraft/protocol/packet/player_auth_input.go
+++ b/minecraft/protocol/packet/player_auth_input.go
@@ -161,14 +161,14 @@ func (pk *PlayerAuthInput) Marshal(io protocol.IO) {
 	if pk.InputData&InputFlagPerformItemStackRequest != 0 {
 		protocol.Single(io, &pk.ItemStackRequest)
 	}
-
+	
+	if pk.InputData&InputFlagPerformBlockActions != 0 {
+		protocol.SliceVarint32Length(io, &pk.BlockActions)
+	}
+	
 	if pk.InputData&InputFlagClientPredictedVehicle != 0 {
 		io.Vec2(&pk.VehicleRotation)
 		io.Varint64(&pk.ClientPredictedVehicle)
-	}
-
-	if pk.InputData&InputFlagPerformBlockActions != 0 {
-		protocol.SliceVarint32Length(io, &pk.BlockActions)
 	}
 
 	io.Vec2(&pk.AnalogueMoveVector)


### PR DESCRIPTION
FIX varint overflows integer when in a boat and breaking a block

![image](https://github.com/user-attachments/assets/53749647-380e-4815-86b8-96e0bcf5724e)
