### PR TITLE
Fix Broken Event Handling in events.go

### DIFF
--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -59,8 +59,12 @@ func lookupEvent(eventType int32, x *Event) bool {
 		*x = &AgentCommandEvent{}
 	case EventTypeSlashCommandExecuted:
 		*x = &SlashCommandExecutedEvent{}
+	case EventTypeFishBucketed:
+		*x = &FishBucketedEvent{}
 	case EventTypeMobBorn:
 		*x = &MobBornEvent{}
+	case EventTypePetDied:
+		*x = &PetDiedEvent{}
 	case EventTypeCauldronInteract:
 		*x = &CauldronInteractEvent{}
 	case EventTypeComposterInteract:
@@ -71,6 +75,12 @@ func lookupEvent(eventType int32, x *Event) bool {
 		*x = &EntityDefinitionTriggerEvent{}
 	case EventTypeRaidUpdate:
 		*x = &RaidUpdateEvent{}
+	case EventTypeMovementAnomaly:
+		*x = &MovementAnomalyEvent{}
+	case EventTypeMovementCorrected:
+		*x = &MovementCorrectedEvent{}
+	case EventTypeExtractHoney:
+		*x = &ExtractHoneyEvent{}
 	case EventTypeTargetBlockHit:
 		*x = &TargetBlockHitEvent{}
 	case EventTypePiglinBarter:
@@ -81,6 +91,12 @@ func lookupEvent(eventType int32, x *Event) bool {
 		*x = &CodeBuilderRuntimeActionEvent{}
 	case EventTypeCodeBuilderScoreboard:
 		*x = &CodeBuilderScoreboardEvent{}
+	case EventTypeStriderRiddenInLavaInOverworld:
+		*x = &StriderRiddenInLavaInOverworldEvent{}
+	case EventTypeSneakCloseToSculkSensor:
+		*x = &SneakCloseToSculkSensorEvent{}
+	case EventTypeCarefulRestoration:
+		*x = &CarefulRestorationEvent{}
 	case EventTypeItemUsed:
 		*x = &ItemUsedEvent{}
 	default:
@@ -112,8 +128,12 @@ func lookupEventType(x Event, eventType *int32) bool {
 		*eventType = EventTypeAgentCommand
 	case *SlashCommandExecutedEvent:
 		*eventType = EventTypeSlashCommandExecuted
+	case *FishBucketedEvent:
+		*eventType = EventTypeFishBucketed
 	case *MobBornEvent:
 		*eventType = EventTypeMobBorn
+	case *PetDiedEvent:
+		*eventType = EventTypePetDied
 	case *CauldronInteractEvent:
 		*eventType = EventTypeCauldronInteract
 	case *ComposterInteractEvent:
@@ -124,12 +144,28 @@ func lookupEventType(x Event, eventType *int32) bool {
 		*eventType = EventTypeEntityDefinitionTrigger
 	case *RaidUpdateEvent:
 		*eventType = EventTypeRaidUpdate
+	case *MovementAnomalyEvent:
+		*eventType = EventTypeMovementAnomaly
+	case *MovementCorrectedEvent:
+		*eventType = EventTypeMovementCorrected
+	case *ExtractHoneyEvent:
+		*eventType = EventTypeExtractHoney
 	case *TargetBlockHitEvent:
 		*eventType = EventTypeTargetBlockHit
 	case *PiglinBarterEvent:
 		*eventType = EventTypePiglinBarter
 	case *WaxedOrUnwaxedCopperEvent:
 		*eventType = EventTypePlayerWaxedOrUnwaxedCopper
+	case *CodeBuilderRuntimeActionEvent:
+		*eventType = EventTypeCodeBuilderRuntimeAction
+	case *CodeBuilderScoreboardEvent:
+		*eventType = EventTypeCodeBuilderScoreboard
+	case *StriderRiddenInLavaInOverworldEvent:
+		*eventType = EventTypeStriderRiddenInLavaInOverworld
+	case *SneakCloseToSculkSensorEvent:
+		*eventType = EventTypeSneakCloseToSculkSensor
+	case *CarefulRestorationEvent:
+		*eventType = EventTypeCarefulRestoration
 	case *ItemUsedEvent:
 		*eventType = EventTypeItemUsed
 	default:
@@ -327,6 +363,12 @@ func (s *SlashCommandExecutedEvent) Marshal(r IO) {
 	r.String(&s.OutputMessages)
 }
 
+// FishBucketedEvent is the event data sent when a fish is bucketed.
+type FishBucketedEvent struct{}
+
+// Marshal ...
+func (f *FishBucketedEvent) Marshal(r IO) {}
+
 // MobBornEvent is the event data sent when a mob is born.
 type MobBornEvent struct {
 	// EntityType ...
@@ -343,6 +385,12 @@ func (m *MobBornEvent) Marshal(r IO) {
 	r.Varint32(&m.Variant)
 	r.Uint8(&m.Colour)
 }
+
+// PetDiedEvent is the event data sent when a pet dies.
+type PetDiedEvent struct{}
+
+// Marshal ...
+func (p *PetDiedEvent) Marshal(r IO) {}
 
 // CauldronInteractEvent is the event data sent when a cauldron is interacted with.
 type CauldronInteractEvent struct {
@@ -411,7 +459,25 @@ func (ra *RaidUpdateEvent) Marshal(r IO) {
 	r.Bool(&ra.WonRaid)
 }
 
-// TargetBlockHitEvent is a event that is called when a target block is hit with a arrow.
+// MovementAnomalyEvent is an event used to detect movement anomalies.
+type MovementAnomalyEvent struct{}
+
+// Marshal ...
+func (m *MovementAnomalyEvent) Marshal(r IO) {}
+
+// MovementCorrectedEvent is an event used to correct movement anomalies.
+type MovementCorrectedEvent struct{}
+
+// Marshal ...
+func (m *MovementCorrectedEvent) Marshal(r IO) {}
+
+// ExtractHoneyEvent is an event used to extract honey from a hive.
+type ExtractHoneyEvent struct{}
+
+// Marshal ...
+func (e *ExtractHoneyEvent) Marshal(r IO) {}
+
+// TargetBlockHitEvent is an event used when a target block is hit by a arrow.
 type TargetBlockHitEvent struct {
 	// RedstoneLevel ...
 	RedstoneLevel int32
@@ -481,6 +547,24 @@ func (c *CodeBuilderScoreboardEvent) Marshal(r IO) {
 	r.String(&c.ObjectiveName)
 	r.Varint32(&c.Score)
 }
+
+// StriderRiddenInLavaInOverworldEvent is an event sent by the server when a strider is ridden in lava in the overworld.
+type StriderRiddenInLavaInOverworldEvent struct{}
+
+// Marshal ...
+func (s *StriderRiddenInLavaInOverworldEvent) Marshal(r IO) {}
+
+// SneakCloseToSculkSensorEvent is an event sent by the server when a player sneaks close to a sculk sensor.
+type SneakCloseToSculkSensorEvent struct{}
+
+// Marshal ...
+func (s *SneakCloseToSculkSensorEvent) Marshal(r IO) {}
+
+// CarefulRestorationEvent is an event sent by the server when a player performs a careful restoration.
+type CarefulRestorationEvent struct{}
+
+// Marshal ...
+func (c *CarefulRestorationEvent) Marshal(r IO) {}
 
 // ItemUsedEvent is when a player right clicks a item.
 type ItemUsedEvent struct {

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -315,8 +315,8 @@ type SlashCommandExecutedEvent struct {
 	MessageCount int32
 	// CommandName ...
 	CommandName string
-	// ErrorList is a list of messages joint with ;.
-	ErrorList string
+	// OutputMessages is a list of messages joint with ;.
+	OutputMessages string
 }
 
 // Marshal ...

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -316,7 +316,7 @@ type SlashCommandExecutedEvent struct {
 	// CommandName ...
 	CommandName string
 	// ErrorList is a list of messages joint with ;.
-	OutputMessages string
+	ErrorList string
 }
 
 // Marshal ...

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -57,6 +57,8 @@ func lookupEvent(eventType int32, x *Event) bool {
 		*x = &BossKilledEvent{}
 	case EventTypeAgentCommand:
 		*x = &AgentCommandEvent{}
+	case EventTypePatternRemoved:
+		*x = &PatternRemovedEvent{}
 	case EventTypeSlashCommandExecuted:
 		*x = &SlashCommandExecutedEvent{}
 	case EventTypeFishBucketed:
@@ -126,6 +128,8 @@ func lookupEventType(x Event, eventType *int32) bool {
 		*eventType = EventTypeBossKilled
 	case *AgentCommandEvent:
 		*eventType = EventTypeAgentCommand
+	case *PatternRemovedEvent:
+		*eventType = EventTypePatternRemoved
 	case *SlashCommandExecutedEvent:
 		*eventType = EventTypeSlashCommandExecuted
 	case *FishBucketedEvent:
@@ -342,6 +346,12 @@ func (a *AgentCommandEvent) Marshal(r IO) {
 	r.String(&a.DataKey)
 	r.String(&a.Output)
 }
+
+// PatternRemovedEvent is the event data sent when a pattern is removed.
+type PatternRemovedEvent struct{}
+
+// Marshal ...
+func (p *PatternRemovedEvent) Marshal(r IO) {}
 
 // SlashCommandExecutedEvent is the event data sent when a slash command is executed.
 type SlashCommandExecutedEvent struct {

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -411,7 +411,7 @@ func (ra *RaidUpdateEvent) Marshal(r IO) {
 	r.Bool(&ra.WonRaid)
 }
 
-// TargetBlockHitEvent ...
+// TargetBlockHitEvent is a event that is called when a target block is hit with a error.
 type TargetBlockHitEvent struct {
 	// RedstoneLevel ...
 	RedstoneLevel int32
@@ -422,7 +422,7 @@ func (t *TargetBlockHitEvent) Marshal(r IO) {
 	r.Varint32(&t.RedstoneLevel)
 }
 
-// PiglinBarterEvent ...
+// PiglinBarterEvent is called when a player drops gold ingots to a piglin to initiate a trade for an item.
 type PiglinBarterEvent struct {
 	// ItemID ...
 	ItemID int32
@@ -482,7 +482,7 @@ func (c *CodeBuilderScoreboardEvent) Marshal(r IO) {
 	r.Varint32(&c.Score)
 }
 
-// ItemUsedEvent ...
+// ItemUsedEvent is when a player right clicks a item.
 type ItemUsedEvent struct {
 	ItemID    int16
 	ItemAux   int32

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -411,6 +411,7 @@ func (ra *RaidUpdateEvent) Marshal(r IO) {
 	r.Bool(&ra.WonRaid)
 }
 
+// TargetBlockHitEvent ...
 type TargetBlockHitEvent struct {
 	// RedstoneLevel ...
 	RedstoneLevel int32
@@ -421,6 +422,7 @@ func (t *TargetBlockHitEvent) Marshal(r IO) {
 	r.Varint32(&t.RedstoneLevel)
 }
 
+// PiglinBarterEvent ...
 type PiglinBarterEvent struct {
 	// ItemID ...
 	ItemID int32
@@ -480,6 +482,7 @@ func (c *CodeBuilderScoreboardEvent) Marshal(r IO) {
 	r.Varint32(&c.Score)
 }
 
+// ItemUsedEvent ...
 type ItemUsedEvent struct {
 	ItemID    int16
 	ItemAux   int32

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -141,7 +141,7 @@ func lookupEventType(x Event, eventType *int32) bool {
 // Event represents an object that holds data specific to an event.
 // The data it holds depends on the type.
 type Event interface {
-	// Marshal encodes/decodes a serialized event data object.
+	// Marshal encodes/decodes a serialised event data object.
 	Marshal(r IO)
 }
 
@@ -166,8 +166,8 @@ type EntityInteractEvent struct {
 	InteractionActorType int32
 	// EntityVariant ...
 	InteractionActorVariant int32
-	// EntityColor ...
-	InteractionActorColor uint8
+	// EntityColour ...
+	InteractionActorColour uint8
 }
 
 // Marshal ...
@@ -176,7 +176,7 @@ func (e *EntityInteractEvent) Marshal(r IO) {
 	r.Varint32(&e.InteractionType)
 	r.Varint32(&e.InteractionActorType)
 	r.Varint32(&e.InteractionActorVariant)
-	r.Uint8(&e.InteractionActorColor)
+	r.Uint8(&e.InteractionActorColour)
 }
 
 // PortalBuiltEvent is the event data sent when a portal is built.
@@ -232,8 +232,8 @@ func (m *MobKilledEvent) Marshal(r IO) {
 
 // CauldronUsedEvent is the event data sent when a cauldron is used.
 type CauldronUsedEvent struct {
-	// Color ...
-	Color uint32
+	// Colour ...
+	Colour uint32
 	// PotionID ...
 	ContentsType int32
 	// FillLevel ...
@@ -242,7 +242,7 @@ type CauldronUsedEvent struct {
 
 // Marshal ...
 func (c *CauldronUsedEvent) Marshal(r IO) {
-	r.Varuint32(&c.Color)
+	r.Varuint32(&c.Colour)
 	r.Varint32(&c.ContentsType)
 	r.Varint32(&c.FillLevel)
 }
@@ -333,15 +333,15 @@ type MobBornEvent struct {
 	EntityType int32
 	// Variant ...
 	Variant int32
-	// Color ...
-	Color uint8
+	// Colour ...
+	Colour uint8
 }
 
 // Marshal ...
 func (m *MobBornEvent) Marshal(r IO) {
 	r.Varint32(&m.EntityType)
 	r.Varint32(&m.Variant)
-	r.Uint8(&m.Color)
+	r.Uint8(&m.Colour)
 }
 
 // CauldronInteractEvent is the event data sent when a cauldron is interacted with.
@@ -435,14 +435,14 @@ func (p *PiglinBarterEvent) Marshal(r IO) {
 }
 
 const (
-	WaxNotOxidized   = uint16(0xa609)
+	WaxNotOxidised   = uint16(0xa609)
 	WaxExposed       = uint16(0xa809)
 	WaxWeathered     = uint16(0xaa09)
-	WaxOxidized      = uint16(0xac09)
-	UnWaxNotOxidized = uint16(0xae09)
+	WaxOxidised      = uint16(0xac09)
+	UnWaxNotOxidised = uint16(0xae09)
 	UnWaxExposed     = uint16(0xb009)
 	UnWaxWeathered   = uint16(0xb209)
-	UnWaxOxidized    = uint16(0xfa0a)
+	UnWaxOxidised    = uint16(0xfa0a)
 )
 
 // WaxedOrUnwaxedCopperEvent is an event sent by the server when a copper block is waxed or unwaxed.

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -163,20 +163,20 @@ type EntityInteractEvent struct {
 	// InteractionType ...
 	InteractionType int32
 	// InteractionEntityType ...
-	InteractionActorType int32
+	InteractionEntityType int32
 	// EntityVariant ...
-	InteractionActorVariant int32
+	EntityVariant int32
 	// EntityColour ...
-	InteractionActorColour uint8
+	EntityColour uint8
 }
 
 // Marshal ...
 func (e *EntityInteractEvent) Marshal(r IO) {
 	r.Varint64(&e.InteractedEntityID)
 	r.Varint32(&e.InteractionType)
-	r.Varint32(&e.InteractionActorType)
-	r.Varint32(&e.InteractionActorVariant)
-	r.Uint8(&e.InteractionActorColour)
+	r.Varint32(&e.InteractionEntityType)
+	r.Varint32(&e.EntityVariant)
+	r.Uint8(&e.EntityColour)
 }
 
 // PortalBuiltEvent is the event data sent when a portal is built.
@@ -206,14 +206,14 @@ func (p *PortalUsedEvent) Marshal(r IO) {
 
 // MobKilledEvent is the event data sent when a mob is killed.
 type MobKilledEvent struct {
-	// InstigatorActorID ...
-	InstigatorActorID int64
-	// TargetActorID ...
-	TargetActorID int64
-	// InstigatorsChildActorType ...
-	InstigatorsChildActorType int32
-	// DamageSource ...
-	DamageSource int32
+	// KillerEntityUniqueID ...
+	KillerEntityUniqueID int64
+	// VictimEntityUniqueID ...
+	VictimEntityUniqueID int64
+	// KillerEntityType ...
+	KillerEntityType int32
+	// EntityDamageCause ...
+	EntityDamageCause int32
 	// VillagerTradeTier -1 if not a trading actor.
 	VillagerTradeTier int32
 	// VillagerDisplayName Empty if not a trading actor.
@@ -222,10 +222,10 @@ type MobKilledEvent struct {
 
 // Marshal ...
 func (m *MobKilledEvent) Marshal(r IO) {
-	r.Varint64(&m.InstigatorActorID)
-	r.Varint64(&m.TargetActorID)
-	r.Varint32(&m.InstigatorsChildActorType)
-	r.Varint32(&m.DamageSource)
+	r.Varint64(&m.KillerEntityUniqueID)
+	r.Varint64(&m.VictimEntityUniqueID)
+	r.Varint32(&m.KillerEntityType)
+	r.Varint32(&m.EntityDamageCause)
 	r.Varint32(&m.VillagerTradeTier)
 	r.String(&m.VillagerDisplayName)
 }
@@ -312,19 +312,19 @@ type SlashCommandExecutedEvent struct {
 	// SuccessCount ...
 	SuccessCount int32
 	// ErrorCount indicates the amount of OutputMessages present.
-	ErrorCount int32
+	MessageCount int32
 	// CommandName ...
 	CommandName string
 	// ErrorList is a list of messages joint with ;.
-	ErrorList string
+	OutputMessages string
 }
 
 // Marshal ...
 func (s *SlashCommandExecutedEvent) Marshal(r IO) {
 	r.Varint32(&s.SuccessCount)
-	r.Varint32(&s.ErrorCount)
+	r.Varint32(&s.MessageCount)
 	r.String(&s.CommandName)
-	r.String(&s.ErrorList)
+	r.String(&s.OutputMessages)
 }
 
 // MobBornEvent is the event data sent when a mob is born.

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -411,7 +411,7 @@ func (ra *RaidUpdateEvent) Marshal(r IO) {
 	r.Bool(&ra.WonRaid)
 }
 
-// TargetBlockHitEvent is a event that is called when a target block is hit with a error.
+// TargetBlockHitEvent is a event that is called when a target block is hit with a arrow.
 type TargetBlockHitEvent struct {
 	// RedstoneLevel ...
 	RedstoneLevel int32

--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -235,7 +235,7 @@ type CauldronUsedEvent struct {
 	// Colour ...
 	Colour uint32
 	// PotionID ...
-	ContentsType int32
+	PotionID int32
 	// FillLevel ...
 	FillLevel int32
 }
@@ -243,7 +243,7 @@ type CauldronUsedEvent struct {
 // Marshal ...
 func (c *CauldronUsedEvent) Marshal(r IO) {
 	r.Varuint32(&c.Colour)
-	r.Varint32(&c.ContentsType)
+	r.Varint32(&c.PotionID)
 	r.Varint32(&c.FillLevel)
 }
 
@@ -311,7 +311,7 @@ func (a *AgentCommandEvent) Marshal(r IO) {
 type SlashCommandExecutedEvent struct {
 	// SuccessCount ...
 	SuccessCount int32
-	// ErrorCount indicates the amount of OutputMessages present.
+	// MessageCount indicates the amount of OutputMessages present.
 	MessageCount int32
 	// CommandName ...
 	CommandName string


### PR DESCRIPTION
Fixed Events.go from random varint overflows and fixed/updated and deleted to match the current state of Minecraft bedrock.