### PR TITLE
Improve closed connection error messages

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -1352,10 +1352,8 @@ func (conn *Conn) handlePlayStatus(pk *packet.PlayStatus) error {
 		conn.expect(packet.IDResourcePacksInfo)
 		return conn.Flush()
 	case packet.PlayStatusLoginFailedClient:
-		_ = conn.Close()
 		return fmt.Errorf("client outdated")
 	case packet.PlayStatusLoginFailedServer:
-		_ = conn.Close()
 		return fmt.Errorf("server outdated")
 	case packet.PlayStatusPlayerSpawn:
 		// We've spawned and can send the last packet in the spawn sequence.
@@ -1363,22 +1361,16 @@ func (conn *Conn) handlePlayStatus(pk *packet.PlayStatus) error {
 		conn.tryFinaliseClientConn()
 		return nil
 	case packet.PlayStatusLoginFailedInvalidTenant:
-		_ = conn.Close()
 		return fmt.Errorf("invalid edu edition game owner")
 	case packet.PlayStatusLoginFailedVanillaEdu:
-		_ = conn.Close()
 		return fmt.Errorf("cannot join an edu edition game on vanilla")
 	case packet.PlayStatusLoginFailedEduVanilla:
-		_ = conn.Close()
 		return fmt.Errorf("cannot join a vanilla game on edu edition")
 	case packet.PlayStatusLoginFailedServerFull:
-		_ = conn.Close()
 		return fmt.Errorf("server full")
 	case packet.PlayStatusLoginFailedEditorVanilla:
-		_ = conn.Close()
 		return fmt.Errorf("cannot join a vanilla game on editor")
 	case packet.PlayStatusLoginFailedVanillaEditor:
-		_ = conn.Close()
 		return fmt.Errorf("cannot join an editor game on vanilla")
 	default:
 		return fmt.Errorf("unknown play status %v", pk.Status)

--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -218,8 +218,8 @@ func (d Dialer) DialContext(ctx context.Context, network, address string) (conn 
 		conn.identityData = identityData
 	}
 
-	l, c := make(chan struct{}), make(chan struct{})
-	go listenConn(conn, d.ErrorLog, l, c)
+	l, c, e := make(chan struct{}), make(chan struct{}), make(chan error, 1)
+	go listenConn(conn, d.ErrorLog, l, c, e)
 
 	conn.expect(packet.IDNetworkSettings, packet.IDPlayStatus)
 	if err := conn.WritePacket(&packet.RequestNetworkSettings{ClientProtocol: d.Protocol.ID()}); err != nil {
@@ -232,6 +232,8 @@ func (d Dialer) DialContext(ctx context.Context, network, address string) (conn 
 		return nil, conn.closeErr("dial")
 	case <-ctx.Done():
 		return nil, conn.wrap(ctx.Err(), "dial")
+	case err := <-e:
+		return nil, conn.wrap(err, "dial")
 	case <-l:
 		// We've received our network settings, so we can now send our login request.
 		conn.expect(packet.IDServerToClientHandshake, packet.IDPlayStatus)
@@ -245,6 +247,8 @@ func (d Dialer) DialContext(ctx context.Context, network, address string) (conn 
 			return nil, conn.closeErr("dial")
 		case <-ctx.Done():
 			return nil, conn.wrap(ctx.Err(), "dial")
+		case err := <-e:
+			return nil, conn.wrap(err, "dial")
 		case <-c:
 			// We've connected successfully. We return the connection and no error.
 			return conn, nil
@@ -278,7 +282,7 @@ func readChainIdentityData(chainData []byte) login.IdentityData {
 
 // listenConn listens on the connection until it is closed on another goroutine. The channel passed will
 // receive a value once the connection is logged in.
-func listenConn(conn *Conn, logger *log.Logger, l, c chan struct{}) {
+func listenConn(conn *Conn, logger *log.Logger, l, c chan struct{}, e chan error) {
 	defer func() {
 		_ = conn.Close()
 	}()
@@ -290,12 +294,14 @@ func listenConn(conn *Conn, logger *log.Logger, l, c chan struct{}) {
 			if !errors.Is(err, net.ErrClosed) {
 				logger.Printf("dialer conn: %v\n", err)
 			}
+			e <- err
 			return
 		}
 		for _, data := range packets {
 			loggedInBefore, readyToLoginBefore := conn.loggedIn, conn.readyToLogin
 			if err := conn.receive(data); err != nil {
 				logger.Printf("dialer conn: %v", err)
+				e <- err
 				return
 			}
 			if !readyToLoginBefore && conn.readyToLogin {


### PR DESCRIPTION
This PR improves error messages when handling packets.
These messages were written to the debugger before instead of being handled as an error

Before:
DEBU[0005] dial attempt 1: dial minecraft 192.168.140.68:64906->162.248.102.67:19132: use of closed connection

After:
DEBU[0005] dial attempt 1 failed: dial minecraft 12.168.140.68:64906->162.248.102.67:19132: handle *packet.PlayStatus: server outdated

The removed lines `_ = conn.Close()` should not make a difference they are already handled immediately in the following places:
https://github.com/Sandertv/gophertunnel/blob/aed4aa48e09ecc81cf35f4e2625d41ff2efd1e52/minecraft/dial.go#L282
https://github.com/Sandertv/gophertunnel/blob/aed4aa48e09ecc81cf35f4e2625d41ff2efd1e52/minecraft/listener.go#L298
The reason for removal is so the select can catch the error before the closed conn