### PR TITLE
protocol/item_stack.go: Add missing field for CraftLoomRecipeStackRequestAction

### DIFF
--- a/minecraft/protocol/item_stack.go
+++ b/minecraft/protocol/item_stack.go
@@ -564,11 +564,14 @@ func (c *CraftGrindstoneRecipeStackRequestAction) Marshal(r IO) {
 type CraftLoomRecipeStackRequestAction struct {
 	// Pattern is the pattern identifier for the loom recipe.
 	Pattern string
+	// TimesCrafted is how many times the recipe was crafted.
+	TimesCrafted byte
 }
 
 // Marshal ...
 func (c *CraftLoomRecipeStackRequestAction) Marshal(r IO) {
 	r.String(&c.Pattern)
+	r.Uint8(&c.TimesCrafted)
 }
 
 // CraftNonImplementedStackRequestAction is an action sent for inventory actions that aren't yet implemented


### PR DESCRIPTION
See https://github.com/CloudburstMC/Protocol/commit/e50b8063fab2b71e8d4544ffc632dc429f786ad8#diff-bba6169d3c68dbe90a4d2d703ae110b0ea795b5b792aca6ac4894738b3af3482R70