### PR TITLE
Update pool.go to fix `unexpected packet (ID=132)` error.

### DIFF
--- a/minecraft/protocol/packet/pool.go
+++ b/minecraft/protocol/packet/pool.go
@@ -317,6 +317,7 @@ func init() {
 		IDLecternUpdate:                   func() Packet { return &LecternUpdate{} },
 		IDClientCacheStatus:               func() Packet { return &ClientCacheStatus{} },
 		IDMapCreateLockedCopy:             func() Packet { return &MapCreateLockedCopy{} },
+		IDStructureTemplateDataExportRequest:  func() Packet { return &StructureTemplateDataRequest{} },
 		IDStructureTemplateDataResponse:   func() Packet { return &StructureTemplateDataResponse{} },
 		IDClientCacheBlobStatus:           func() Packet { return &ClientCacheBlobStatus{} },
 		IDEmote:                           func() Packet { return &Emote{} },


### PR DESCRIPTION
This packet wasn't marked as a client sent packet, which caused a read packet error.