### PR TITLE
Add BitSet.Len()

### DIFF
--- a/minecraft/protocol/bitset.go
+++ b/minecraft/protocol/bitset.go
@@ -41,3 +41,8 @@ func (b Bitset) Load(i int) bool {
 	}
 	return b.int.Bit(i) == 1
 }
+
+// Size returns the size of the Bitset.
+func (b Bitset) Size() int {
+	return b.size
+}

--- a/minecraft/protocol/bitset.go
+++ b/minecraft/protocol/bitset.go
@@ -42,7 +42,7 @@ func (b Bitset) Load(i int) bool {
 	return b.int.Bit(i) == 1
 }
 
-// Size returns the size of the Bitset.
-func (b Bitset) Size() int {
+// Len returns the size of the Bitset.
+func (b Bitset) Len() int {
 	return b.size
 }


### PR DESCRIPTION
BitSet.Len() is needed for multi-protocol support purposes. 

Also in C++, there's `size()` method: https://en.cppreference.com/w/cpp/utility/bitset/size