### PR TITLE
Add EntityUniqueId to ClientMovementPredictionSync

### DIFF
--- a/minecraft/protocol/packet/client_movement_prediction_sync.go
+++ b/minecraft/protocol/packet/client_movement_prediction_sync.go
@@ -28,6 +28,8 @@ type ClientMovementPredictionSync struct {
 	Health float32
 	// Hunger is the hunger attribute or 0 if not set.
 	Hunger float32
+	// ActorUniqueId
+	ActorUniqueId int64
 }
 
 // ID ...
@@ -46,4 +48,5 @@ func (pk *ClientMovementPredictionSync) Marshal(io protocol.IO) {
 	io.Float32(&pk.JumpStrength)
 	io.Float32(&pk.Health)
 	io.Float32(&pk.Hunger)
+	io.Varint64(&pk.ActorUniqueId)
 }

--- a/minecraft/protocol/packet/client_movement_prediction_sync.go
+++ b/minecraft/protocol/packet/client_movement_prediction_sync.go
@@ -28,8 +28,9 @@ type ClientMovementPredictionSync struct {
 	Health float32
 	// Hunger is the hunger attribute or 0 if not set.
 	Hunger float32
-	// ActorUniqueId
-	ActorUniqueId int64
+	// EntityUniqueID is the unique ID of the entity. The unique ID is a value that remains consistent across
+	// different sessions of the same world.
+	EntityUniqueId int64
 }
 
 // ID ...
@@ -48,5 +49,5 @@ func (pk *ClientMovementPredictionSync) Marshal(io protocol.IO) {
 	io.Float32(&pk.JumpStrength)
 	io.Float32(&pk.Health)
 	io.Float32(&pk.Hunger)
-	io.Varint64(&pk.ActorUniqueId)
+	io.Varint64(&pk.EntityUniqueId)
 }

--- a/minecraft/protocol/packet/client_movement_prediction_sync.go
+++ b/minecraft/protocol/packet/client_movement_prediction_sync.go
@@ -30,7 +30,7 @@ type ClientMovementPredictionSync struct {
 	Hunger float32
 	// EntityUniqueID is the unique ID of the entity. The unique ID is a value that remains consistent across
 	// different sessions of the same world.
-	EntityUniqueId int64
+	EntityUniqueID int64
 }
 
 // ID ...
@@ -49,5 +49,5 @@ func (pk *ClientMovementPredictionSync) Marshal(io protocol.IO) {
 	io.Float32(&pk.JumpStrength)
 	io.Float32(&pk.Health)
 	io.Float32(&pk.Hunger)
-	io.Varint64(&pk.EntityUniqueId)
+	io.Varint64(&pk.EntityUniqueID)
 }


### PR DESCRIPTION
Looks like this was missed in a protocol update, sometimes got a bad packet read (/disconnect) because of the unread bytes at end.