### PR TITLE
improve http usage, pass contexts, check errors, small memory leaks

### DIFF
--- a/minecraft/auth/live.go
+++ b/minecraft/auth/live.go
@@ -108,9 +108,7 @@ func startDeviceAuth() (*deviceAuthConnect, error) {
 	if err != nil {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_connect.srf: %w", err)
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_connect.srf: %v", resp.Status)
 	}
@@ -129,9 +127,7 @@ func pollDeviceAuth(deviceCode string) (t *oauth2.Token, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_token.srf: %w", err)
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 	poll := new(deviceAuthPoll)
 	if err := json.NewDecoder(resp.Body).Decode(poll); err != nil {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_token.srf: json decode: %w", err)
@@ -163,9 +159,7 @@ func refreshToken(t *oauth2.Token) (*oauth2.Token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_token.srf: %w", err)
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 	poll := new(deviceAuthPoll)
 	if err := json.NewDecoder(resp.Body).Decode(poll); err != nil {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_token.srf: json decode: %w", err)

--- a/minecraft/auth/live.go
+++ b/minecraft/auth/live.go
@@ -129,11 +129,13 @@ func pollDeviceAuth(deviceCode string) (t *oauth2.Token, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_token.srf: %w", err)
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	poll := new(deviceAuthPoll)
 	if err := json.NewDecoder(resp.Body).Decode(poll); err != nil {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_token.srf: json decode: %w", err)
 	}
-	_ = resp.Body.Close()
 	if poll.Error == "authorization_pending" {
 		return nil, nil
 	} else if poll.Error == "" {
@@ -161,11 +163,13 @@ func refreshToken(t *oauth2.Token) (*oauth2.Token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_token.srf: %w", err)
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	poll := new(deviceAuthPoll)
 	if err := json.NewDecoder(resp.Body).Decode(poll); err != nil {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_token.srf: json decode: %w", err)
 	}
-	_ = resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("POST https://login.live.com/oauth20_token.srf: refresh error: %v", poll.Error)
 	}

--- a/minecraft/auth/minecraft.go
+++ b/minecraft/auth/minecraft.go
@@ -6,10 +6,11 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
 )
 
 // minecraftAuthURL is the URL that an authentication request is made to to get an encoded JWT claim chain.
@@ -24,25 +25,30 @@ func RequestMinecraftChain(ctx context.Context, token *XBLToken, key *ecdsa.Priv
 	// The body of the requests holds a JSON object with one key in it, the 'identityPublicKey', which holds
 	// the public key data of the private key passed.
 	body := `{"identityPublicKey":"` + base64.StdEncoding.EncodeToString(data) + `"}`
-	request, _ := http.NewRequestWithContext(ctx, "POST", minecraftAuthURL, strings.NewReader(body))
-	request.Header.Set("Content-Type", "application/json")
+	request, err := http.NewRequestWithContext(ctx, "POST", minecraftAuthURL, strings.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("POST %v: %w", minecraftAuthURL, err)
+	}
 
 	// The Authorization header is important in particular. It is composed of the 'uhs' found in the XSTS
 	// token, and the Token it holds itself.
 	token.SetAuthHeader(request)
 	request.Header.Set("User-Agent", "MCPE/Android")
 	request.Header.Set("Client-Version", protocol.CurrentVersion)
+	request.Header.Set("Content-Type", "application/json")
 
 	c := &http.Client{}
 	resp, err := c.Do(request)
 	if err != nil {
 		return "", fmt.Errorf("POST %v: %w", minecraftAuthURL, err)
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != 200 {
 		return "", fmt.Errorf("POST %v: %v", minecraftAuthURL, resp.Status)
 	}
 	data, err = io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
 	c.CloseIdleConnections()
 	return string(data), err
 }

--- a/minecraft/auth/minecraft.go
+++ b/minecraft/auth/minecraft.go
@@ -42,9 +42,7 @@ func RequestMinecraftChain(ctx context.Context, token *XBLToken, key *ecdsa.Priv
 	if err != nil {
 		return "", fmt.Errorf("POST %v: %w", minecraftAuthURL, err)
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return "", fmt.Errorf("POST %v: %v", minecraftAuthURL, resp.Status)
 	}

--- a/minecraft/auth/xbox.go
+++ b/minecraft/auth/xbox.go
@@ -65,7 +65,7 @@ func RequestXBLToken(ctx context.Context, liveToken *oauth2.Token, relyingParty 
 }
 
 func obtainXBLToken(ctx context.Context, c *http.Client, key *ecdsa.PrivateKey, liveToken *oauth2.Token, device *deviceToken, relyingParty string) (*XBLToken, error) {
-	data, _ := json.Marshal(map[string]any{
+	data, err := json.Marshal(map[string]any{
 		"AccessToken":       "t=" + liveToken.AccessToken,
 		"AppId":             "0000000048183522",
 		"deviceToken":       device.Token,
@@ -82,7 +82,14 @@ func obtainXBLToken(ctx context.Context, c *http.Client, key *ecdsa.PrivateKey, 
 			"y":   base64.RawURLEncoding.EncodeToString(key.PublicKey.Y.Bytes()),
 		},
 	})
-	req, _ := http.NewRequestWithContext(ctx, "POST", "https://sisu.xboxlive.com/authorize", bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("marshaling XBL auth request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://sisu.xboxlive.com/authorize", bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("POST %v: %w", "https://sisu.xboxlive.com/authorize", err)
+	}
 	req.Header.Set("x-xbl-contract-version", "1")
 	sign(req, data, key)
 
@@ -113,7 +120,7 @@ type deviceToken struct {
 // obtainDeviceToken sends a POST request to the device auth endpoint using the ECDSA private key passed to
 // sign the request.
 func obtainDeviceToken(ctx context.Context, c *http.Client, key *ecdsa.PrivateKey) (token *deviceToken, err error) {
-	data, _ := json.Marshal(map[string]any{
+	data, err := json.Marshal(map[string]any{
 		"RelyingParty": "http://auth.xboxlive.com",
 		"TokenType":    "JWT",
 		"Properties": map[string]any{
@@ -131,7 +138,14 @@ func obtainDeviceToken(ctx context.Context, c *http.Client, key *ecdsa.PrivateKe
 			},
 		},
 	})
-	request, _ := http.NewRequestWithContext(ctx, "POST", "https://device.auth.xboxlive.com/device/authenticate", bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("marshaling device auth request: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", "https://device.auth.xboxlive.com/device/authenticate", bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("POST %v: %w", "https://device.auth.xboxlive.com/device/authenticate", err)
+	}
 	request.Header.Set("x-xbl-contract-version", "1")
 	sign(request, data, key)
 
@@ -220,4 +234,3 @@ func parseXboxErrorCode(code string) string {
 		return fmt.Sprintf("unknown error code: %v", code)
 	}
 }
-

--- a/minecraft/auth/xbox.go
+++ b/minecraft/auth/xbox.go
@@ -97,9 +97,7 @@ func obtainXBLToken(ctx context.Context, c *http.Client, key *ecdsa.PrivateKey, 
 	if err != nil {
 		return nil, fmt.Errorf("POST %v: %w", "https://sisu.xboxlive.com/authorize", err)
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		// Xbox Live returns a custom error code in the x-err header.
 		if errorCode := resp.Header.Get("x-err"); errorCode != "" {
@@ -153,9 +151,7 @@ func obtainDeviceToken(ctx context.Context, c *http.Client, key *ecdsa.PrivateKe
 	if err != nil {
 		return nil, fmt.Errorf("POST %v: %w", "https://device.auth.xboxlive.com/device/authenticate", err)
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("POST %v: %v", "https://device.auth.xboxlive.com/device/authenticate", resp.Status)
 	}

--- a/minecraft/realms/realms.go
+++ b/minecraft/realms/realms.go
@@ -170,9 +170,7 @@ func (r *Client) request(ctx context.Context, path string) (body []byte, status 
 	if err != nil {
 		return nil, 0, err
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {

--- a/minecraft/realms/realms.go
+++ b/minecraft/realms/realms.go
@@ -154,7 +154,7 @@ func (r *Client) request(ctx context.Context, path string) (body []byte, status 
 	if string(path[0]) != "/" {
 		path = "/" + path
 	}
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://pocket.realms.minecraft.net%s", path), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://pocket.realms.minecraft.net%s", path), nil)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -170,7 +170,9 @@ func (r *Client) request(ctx context.Context, path string) (body []byte, status 
 	if err != nil {
 		return nil, 0, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {

--- a/minecraft/resource/pack.go
+++ b/minecraft/resource/pack.go
@@ -55,9 +55,7 @@ func ReadURL(url string) (*Pack, error) {
 	if err != nil {
 		return nil, fmt.Errorf("download resource pack: %w", err)
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("download resource pack: %v (%d)", resp.Status, resp.StatusCode)
 	}

--- a/minecraft/resource/pack.go
+++ b/minecraft/resource/pack.go
@@ -5,14 +5,15 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/muhammadmuzzammil1998/jsonc"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
+	"github.com/muhammadmuzzammil1998/jsonc"
 )
 
 // Pack is a container of a resource pack parsed from a directory or a .zip archive (or .mcpack). It holds
@@ -54,7 +55,9 @@ func ReadURL(url string) (*Pack, error) {
 	if err != nil {
 		return nil, fmt.Errorf("download resource pack: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("download resource pack: %v (%d)", resp.Status, resp.StatusCode)
 	}

--- a/minecraft/resource/pack.go
+++ b/minecraft/resource/pack.go
@@ -5,15 +5,14 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"github.com/google/uuid"
+	"github.com/muhammadmuzzammil1998/jsonc"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"github.com/google/uuid"
-	"github.com/muhammadmuzzammil1998/jsonc"
 )
 
 // Pack is a container of a resource pack parsed from a directory or a .zip archive (or .mcpack). It holds


### PR DESCRIPTION
- Fixes small memory leaks with resp.Body.Close()
- Explicity use defer resp.Body.Close()
- Passes context to NewRequest in realms package
- Checks errors when creating requests
- Checks errors when using json.Marshal in auth package