### PR TITLE
Add error checking when using ecdsa.GenerateKey

### DIFF
--- a/minecraft/auth/xbox.go
+++ b/minecraft/auth/xbox.go
@@ -56,7 +56,10 @@ func RequestXBLToken(ctx context.Context, liveToken *oauth2.Token, relyingParty 
 
 	// We first generate an ECDSA private key which will be used to provide a 'ProofKey' to each of the
 	// requests, and to sign these requests.
-	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating ECDSA key: %w", err)
+	}
 	deviceToken, err := obtainDeviceToken(ctx, c, key)
 	if err != nil {
 		return nil, err

--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -12,6 +12,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
+	"math/rand"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
@@ -21,12 +28,6 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/protocol/login"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 	"golang.org/x/oauth2"
-	"log/slog"
-	"math/rand"
-	"net"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // Dialer allows specifying specific settings for connection to a Minecraft server.
@@ -160,7 +161,10 @@ func (d Dialer) DialContext(ctx context.Context, network, address string) (conn 
 		d.FlushRate = time.Second / 20
 	}
 
-	key, _ := ecdsa.GenerateKey(elliptic.P384(), cryptorand.Reader)
+	key, err := ecdsa.GenerateKey(elliptic.P384(), cryptorand.Reader)
+	if err != nil {
+		return nil, &net.OpError{Op: "dial", Net: "minecraft", Err: fmt.Errorf("generating ECDSA key: %w", err)}
+	}
 	var chainData string
 	if d.TokenSource != nil {
 		chainData, err = authChain(ctx, d.TokenSource, key)

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -130,7 +130,10 @@ func (cfg ListenConfig) Listen(network string, address string) (*Listener, error
 	if err != nil {
 		return nil, err
 	}
-	key, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating ECDSA key: %w", err)
+	}
 	listener := &Listener{
 		cfg:      cfg,
 		listener: netListener,


### PR DESCRIPTION
This can fail rarely but it can still happen especially when running across many different systems