### PR TITLE
Update pool.go to fix `unexpected packet (ID=321)`

### DIFF
--- a/minecraft/protocol/packet/pool.go
+++ b/minecraft/protocol/packet/pool.go
@@ -354,6 +354,7 @@ func init() {
 		IDServerBoundLoadingScreen:        func() Packet { return &ServerBoundLoadingScreen{} },
 		IDServerBoundDiagnostics:          func() Packet { return &ServerBoundDiagnostics{} },
 		IDClientMovementPredictionSync:    func() Packet { return &ClientMovementPredictionSync{} },
+		IDClientCameraAimAssist:           func() Packet { return &ClientCameraAimAssist{} },
 		IDUpdateClientOptions:             func() Packet { return &UpdateClientOptions{} },
 	}
 	for id, pk := range clientOriginating {


### PR DESCRIPTION
Fix error: `time=2025-03-25T18:21:09.571-04:00 level=ERROR msg="read packet: unexpected packet (ID=321)" src=listener raddr=127.0.0.1:53589`