### PR TITLE
Fix listener race condition

### DIFF
--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -237,8 +237,8 @@ func (listener *Listener) listen() {
 		}
 	}()
 	defer func() {
-		close(listener.incoming)
 		close(listener.close)
+		close(listener.incoming)
 		_ = listener.Close()
 	}()
 	for {


### PR DESCRIPTION
this causes a "send on nil channel" panic rarely
making sure listener.close is closed first will make the select return and drop further processing
then we can safely close listener.incoming

https://github.com/Sandertv/gophertunnel/blob/fdd82ea9c23613e7cec2caacb8989c8d9ce091bd/minecraft/listener.go#L322-L331