### PR TITLE
Packet Reordering

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -1212,8 +1212,6 @@ func (conn *Conn) handleResourcePackChunkRequest(pk *packet.ResourcePackChunkReq
 // handleStartGame handles an incoming StartGame packet. It is the signal that the player has been added to a
 // world, and it obtains most of its dedicated properties.
 func (conn *Conn) handleStartGame(pk *packet.StartGame) error {
-	// Record that we've received the StartGame packet
-	// This is crucial for the InvalidOrderC check that requires PlayerAuthInput to be sent after StartGame
 	conn.receivedPackets.Store("gotStartGame", true)
 
 	if matched, _ := regexp.MatchString(`.*\.hivebedrock\.network.*`, conn.clientData.ServerAddress); matched {
@@ -1266,9 +1264,6 @@ func (conn *Conn) handleItemRegistry(pk *packet.ItemRegistry) error {
 			conn.shieldID.Store(int32(item.RuntimeID))
 		}
 	}
-
-	// According to InvalidOrderB anticheat check, we need to wait for these packets
-	// before sending RequestChunkRadius
 
 	// Check if all required packets have been received
 	if conn.haveRequiredPacketsArrived() {

--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -1217,7 +1217,7 @@ func (conn *Conn) handleStartGame(pk *packet.StartGame) error {
 	conn.receivedPackets.Store("gotStartGame", true)
 
 	if matched, _ := regexp.MatchString(`.*\.hivebedrock\.network.*`, conn.clientData.ServerAddress); matched {
-		pk.GameVersion = "1.17.0" //temporary fix for hivebedrock.network
+		pk.BaseGameVersion = "1.17.0" //temporary fix for hivebedrock.network
 	}
 
 	conn.gameData = GameData{


### PR DESCRIPTION
The commit reorganizes packet ordering in gophertunnel to more precisely mimic a genuine Minecraft client. This change helps evade anticheat systems that flag non-standard packet sequences.

The modifications ensure:

- ClientCacheStatus is sent before SetLocalPlayerAsInitialized
- Critical server packets are received before sending RequestChunkRadius
- Packets follow the exact sequence: RequestChunkRadius → Interact → PlayerAuthInput → SetLocalPlayerAsInitialized
- PlayerAuthInput is only sent after receiving StartGame


These changes are essential because modern anticheat systems detect unofficial clients by checking packet timing and order. By replicating the exact behavior of an official client, gophertunnel can connect to protected servers without triggering these security mechanisms.