### PR TITLE
Packet Reordering + Dynamic Game Version Override (Dialer)

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -1212,8 +1212,6 @@ func (conn *Conn) handleResourcePackChunkRequest(pk *packet.ResourcePackChunkReq
 // handleStartGame handles an incoming StartGame packet. It is the signal that the player has been added to a
 // world, and it obtains most of its dedicated properties.
 func (conn *Conn) handleStartGame(pk *packet.StartGame) error {
-	// Record that we've received the StartGame packet
-	// This is crucial for the InvalidOrderC check that requires PlayerAuthInput to be sent after StartGame
 	conn.receivedPackets.Store("gotStartGame", true)
 
 	if matched, _ := regexp.MatchString(`.*\.hivebedrock\.network.*`, conn.clientData.ServerAddress); matched {
@@ -1266,9 +1264,6 @@ func (conn *Conn) handleItemRegistry(pk *packet.ItemRegistry) error {
 			conn.shieldID.Store(int32(item.RuntimeID))
 		}
 	}
-
-	// According to InvalidOrderB anticheat check, we need to wait for these packets
-	// before sending RequestChunkRadius
 
 	// Check if all required packets have been received
 	if conn.haveRequiredPacketsArrived() {

--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -1217,7 +1217,7 @@ func (conn *Conn) handleStartGame(pk *packet.StartGame) error {
 	conn.receivedPackets.Store("gotStartGame", true)
 
 	if matched, _ := regexp.MatchString(`.*\.hivebedrock\.network.*`, conn.clientData.ServerAddress); matched {
-		pk.GameVersion = "1.17.0" //temporary fix for hivebedrock.network
+		pk.BaseGameVersion = "1.17.0" //temporary fix for hivebedrock.network
 	}
 
 	conn.gameData = GameData{

--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -160,19 +160,18 @@ type Conn struct {
 // key is generated.
 func newConn(netConn net.Conn, key *ecdsa.PrivateKey, log *slog.Logger, proto Protocol, flushRate time.Duration, limits bool) *Conn {
 	conn := &Conn{
-		enc:                    packet.NewEncoder(netConn),
-		dec:                    packet.NewDecoder(netConn),
-		salt:                   make([]byte, 16),
-		packets:                make(chan *packetData, 8),
-		additional:             make(chan packet.Packet, 16),
-		spawn:                  make(chan struct{}),
-		conn:                   netConn,
-		privateKey:             key,
-		log:                    log.With("raddr", netConn.RemoteAddr().String()),
-		hdr:                    &packet.Header{},
-		proto:                  proto,
-		readerLimits:           limits,
-		serverVersionOverrides: nil,
+		enc:          packet.NewEncoder(netConn),
+		dec:          packet.NewDecoder(netConn),
+		salt:         make([]byte, 16),
+		packets:      make(chan *packetData, 8),
+		additional:   make(chan packet.Packet, 16),
+		spawn:        make(chan struct{}),
+		conn:         netConn,
+		privateKey:   key,
+		log:          log.With("raddr", netConn.RemoteAddr().String()),
+		hdr:          &packet.Header{},
+		proto:        proto,
+		readerLimits: limits,
 	}
 
 	if c, ok := netConn.(interface{ Context() context.Context }); ok {

--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -99,6 +99,11 @@ type Dialer struct {
 	// the client when an XUID is present without logging in.
 	// For getting this to work with BDS, authentication should be disabled.
 	KeepXBLIdentityData bool
+
+	// BaseGameVersion is a map of server addresses to game versions to use when connecting to those servers.
+	// The keys are regex patterns that match against server addresses, and the values are the game versions
+	// to use when connecting to a server that matches the pattern.
+	BaseGameVersion map[string]string
 }
 
 // Dial dials a Minecraft connection to the address passed over the network passed. The network is typically
@@ -203,6 +208,7 @@ func (d Dialer) DialContext(ctx context.Context, network, address string) (conn 
 	conn.cacheEnabled = d.EnableClientCache
 	conn.disconnectOnInvalidPacket = d.DisconnectOnInvalidPackets
 	conn.disconnectOnUnknownPacket = d.DisconnectOnUnknownPackets
+	conn.serverVersionOverrides = d.BaseGameVersion
 
 	defaultIdentityData(&conn.identityData)
 	defaultClientData(address, conn.identityData.DisplayName, &conn.clientData)

--- a/minecraft/example_dial_test.go
+++ b/minecraft/example_dial_test.go
@@ -2,6 +2,7 @@ package minecraft_test
 
 import (
 	"fmt"
+
 	"github.com/sandertv/gophertunnel/minecraft"
 	"github.com/sandertv/gophertunnel/minecraft/auth"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
@@ -11,6 +12,9 @@ func ExampleDial() {
 	// Create a minecraft.Dialer with an auth.TokenSource to authenticate to the server.
 	dialer := minecraft.Dialer{
 		TokenSource: auth.TokenSource,
+		BaseGameVersion: map[string]string{
+			"^.*\\.hivebedrock\\.network.*$": "1.17.0",
+		},
 	}
 	// Dial a new connection to the target server.
 	address := "mco.mineplex.com:19132"

--- a/minecraft/example_listener_test.go
+++ b/minecraft/example_listener_test.go
@@ -2,6 +2,7 @@ package minecraft_test
 
 import (
 	"fmt"
+
 	"github.com/sandertv/gophertunnel/minecraft"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 )

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -82,9 +82,6 @@ type ListenConfig struct {
 	// Login packet. The function is called with the header of the packet and its raw payload, the address
 	// from which the packet originated, and the destination address.
 	PacketFunc func(header packet.Header, payload []byte, src, dst net.Addr)
-
-	// BaseGameVersion is the base game version of the servers
-	BaseGameVersion map[string]string
 }
 
 // Listener implements a Minecraft listener on top of an unspecific net.Listener. It abstracts away the
@@ -276,7 +273,6 @@ func (listener *Listener) createConn(netConn net.Conn) {
 	conn.authEnabled = !listener.cfg.AuthenticationDisabled
 	conn.disconnectOnUnknownPacket = !listener.cfg.AllowUnknownPackets
 	conn.disconnectOnInvalidPacket = !listener.cfg.AllowInvalidPackets
-	conn.serverVersionOverrides = listener.cfg.BaseGameVersion
 
 	if listener.playerCount.Load() == int32(listener.cfg.MaximumPlayers) && listener.cfg.MaximumPlayers != 0 {
 		// The server was full. We kick the player immediately and close the connection.

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -6,16 +6,17 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/sandertv/gophertunnel/minecraft/internal"
-	"github.com/sandertv/gophertunnel/minecraft/protocol"
-	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
-	"github.com/sandertv/gophertunnel/minecraft/resource"
 	"log/slog"
 	"net"
 	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/sandertv/gophertunnel/minecraft/internal"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+	"github.com/sandertv/gophertunnel/minecraft/resource"
 )
 
 // ListenConfig holds settings that may be edited to change behaviour of a Listener.
@@ -81,6 +82,9 @@ type ListenConfig struct {
 	// Login packet. The function is called with the header of the packet and its raw payload, the address
 	// from which the packet originated, and the destination address.
 	PacketFunc func(header packet.Header, payload []byte, src, dst net.Addr)
+
+	// BaseGameVersion is the base game version of the servers
+	BaseGameVersion map[string]string
 }
 
 // Listener implements a Minecraft listener on top of an unspecific net.Listener. It abstracts away the
@@ -272,6 +276,7 @@ func (listener *Listener) createConn(netConn net.Conn) {
 	conn.authEnabled = !listener.cfg.AuthenticationDisabled
 	conn.disconnectOnUnknownPacket = !listener.cfg.AllowUnknownPackets
 	conn.disconnectOnInvalidPacket = !listener.cfg.AllowInvalidPackets
+	conn.serverVersionOverrides = listener.cfg.BaseGameVersion
 
 	if listener.playerCount.Load() == int32(listener.cfg.MaximumPlayers) && listener.cfg.MaximumPlayers != 0 {
 		// The server was full. We kick the player immediately and close the connection.


### PR DESCRIPTION
### **Feature: Dynamic Game Version Override**
I added a system that lets the client use specific Minecraft versions for different servers. The implementation allows for exact matches or regex patterns against server addresses.

`
dialer := minecraft.Dialer{
    BaseGameVersion: map[string]string{
        ".*\\.hivebedrock\\.network": "1.17.0",
        "play\\.example\\.com": "1.19.0",
    },
}
`

This helps maintain compatibility with servers that require specific game versions without needing code changes.


### **Feature: Packet Reordering**

The commit reorganizes packet ordering in gophertunnel to more precisely mimic a genuine Minecraft client. This change helps evade anticheat systems that flag non-standard packet sequences.

The modifications ensure:

1.     ClientCacheStatus is sent before SetLocalPlayerAsInitialized
2.     Critical server packets are received before sending RequestChunkRadius
3.     Packets follow the exact sequence: RequestChunkRadius → Interact → PlayerAuthInput → SetLocalPlayerAsInitialized
4.     PlayerAuthInput is only sent after receiving StartGame

These changes are essential because modern anticheat systems detect unofficial clients by checking packet timing and order. By replicating the exact behavior of an official client, gophertunnel can connect to protected servers without triggering these security mechanisms.
