### PR TITLE
compression.go: prevent flate decompression bomb attacks

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -58,14 +58,14 @@ type Conn struct {
 	log         *slog.Logger
 	authEnabled bool
 
-	proto               Protocol
-	acceptedProto       []Protocol
-	pool                packet.Pool
-	enc                 *packet.Encoder
-	dec                 *packet.Decoder
-	compression         packet.Compression
-	maxDecompressionLen int
-	readerLimits        bool
+	proto              Protocol
+	acceptedProto      []Protocol
+	pool               packet.Pool
+	enc                *packet.Encoder
+	dec                *packet.Decoder
+	compression        packet.Compression
+	maxDecompressedLen int
+	readerLimits       bool
 
 	disconnectOnUnknownPacket bool
 	disconnectOnInvalidPacket bool
@@ -722,7 +722,7 @@ func (conn *Conn) handleRequestNetworkSettings(pk *packet.RequestNetworkSettings
 	}
 	_ = conn.Flush()
 	conn.enc.EnableCompression(conn.compression)
-	conn.dec.EnableCompression(conn.maxDecompressionLen)
+	conn.dec.EnableCompression(conn.maxDecompressedLen)
 	return nil
 }
 
@@ -733,7 +733,7 @@ func (conn *Conn) handleNetworkSettings(pk *packet.NetworkSettings) error {
 		return fmt.Errorf("unknown compression algorithm %v", pk.CompressionAlgorithm)
 	}
 	conn.enc.EnableCompression(alg)
-	conn.dec.EnableCompression(conn.maxDecompressionLen)
+	conn.dec.EnableCompression(conn.maxDecompressedLen)
 	conn.readyToLogin = true
 	return nil
 }

--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -58,13 +58,14 @@ type Conn struct {
 	log         *slog.Logger
 	authEnabled bool
 
-	proto         Protocol
-	acceptedProto []Protocol
-	pool          packet.Pool
-	enc           *packet.Encoder
-	dec           *packet.Decoder
-	compression   packet.Compression
-	readerLimits  bool
+	proto               Protocol
+	acceptedProto       []Protocol
+	pool                packet.Pool
+	enc                 *packet.Encoder
+	dec                 *packet.Decoder
+	compression         packet.Compression
+	maxDecompressionLen int
+	readerLimits        bool
 
 	disconnectOnUnknownPacket bool
 	disconnectOnInvalidPacket bool
@@ -721,7 +722,7 @@ func (conn *Conn) handleRequestNetworkSettings(pk *packet.RequestNetworkSettings
 	}
 	_ = conn.Flush()
 	conn.enc.EnableCompression(conn.compression)
-	conn.dec.EnableCompression()
+	conn.dec.EnableCompression(conn.maxDecompressionLen)
 	return nil
 }
 
@@ -732,7 +733,7 @@ func (conn *Conn) handleNetworkSettings(pk *packet.NetworkSettings) error {
 		return fmt.Errorf("unknown compression algorithm %v", pk.CompressionAlgorithm)
 	}
 	conn.enc.EnableCompression(alg)
-	conn.dec.EnableCompression()
+	conn.dec.EnableCompression(conn.maxDecompressionLen)
 	conn.readyToLogin = true
 	return nil
 }

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 	"github.com/sandertv/gophertunnel/minecraft/resource"
 	"log/slog"
+	"math"
 	"net"
 	"slices"
 	"sync"
@@ -81,6 +82,10 @@ type ListenConfig struct {
 	// Login packet. The function is called with the header of the packet and its raw payload, the address
 	// from which the packet originated, and the destination address.
 	PacketFunc func(header packet.Header, payload []byte, src, dst net.Addr)
+
+	// MaxDecompressedLen is the maximum length of a decompressed packet that prevents ZIP bombs. If 0,
+	// default value is 16MB (16 * 1024 * 1024). Setting this to a negative integer disables the limit.
+	MaxDecompressedLen int
 }
 
 // Listener implements a Minecraft listener on top of an unspecific net.Listener. It abstracts away the
@@ -119,6 +124,11 @@ func (cfg ListenConfig) Listen(network string, address string) (*Listener, error
 	}
 	if cfg.FlushRate == 0 {
 		cfg.FlushRate = time.Second / 20
+	}
+	if cfg.MaxDecompressedLen == 0 {
+		cfg.MaxDecompressedLen = 16 * 1024 * 1024 // 16MB
+	} else if cfg.MaxDecompressedLen < 0 {
+		cfg.MaxDecompressedLen = math.MaxInt
 	}
 
 	n, ok := networkByID(network, cfg.ErrorLog)
@@ -262,6 +272,7 @@ func (listener *Listener) createConn(netConn net.Conn) {
 	conn := newConn(netConn, listener.key, listener.cfg.ErrorLog, proto{}, listener.cfg.FlushRate, true)
 	conn.acceptedProto = append(listener.cfg.AcceptedProtocols, proto{})
 	conn.compression = listener.cfg.Compression
+	conn.maxDecompressionLen = listener.cfg.MaxDecompressedLen
 	conn.pool = conn.proto.Packets(true)
 
 	conn.packetFunc = listener.cfg.PacketFunc

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -83,8 +83,8 @@ type ListenConfig struct {
 	// from which the packet originated, and the destination address.
 	PacketFunc func(header packet.Header, payload []byte, src, dst net.Addr)
 
-	// MaxDecompressedLen is the maximum length of a decompressed packet that prevents ZIP bombs. If 0,
-	// default value is 16MB (16 * 1024 * 1024). Setting this to a negative integer disables the limit.
+	// MaxDecompressedLen is the maximum length of a decompressed packet to prevent potential exploits. If 0,
+	// the default value is 16MB (16 * 1024 * 1024). Setting this to a negative integer disables the limit.
 	MaxDecompressedLen int
 }
 

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -272,7 +272,7 @@ func (listener *Listener) createConn(netConn net.Conn) {
 	conn := newConn(netConn, listener.key, listener.cfg.ErrorLog, proto{}, listener.cfg.FlushRate, true)
 	conn.acceptedProto = append(listener.cfg.AcceptedProtocols, proto{})
 	conn.compression = listener.cfg.Compression
-	conn.maxDecompressionLen = listener.cfg.MaxDecompressedLen
+	conn.maxDecompressedLen = listener.cfg.MaxDecompressedLen
 	conn.pool = conn.proto.Packets(true)
 
 	conn.packetFunc = listener.cfg.PacketFunc

--- a/minecraft/protocol/packet/compression.go
+++ b/minecraft/protocol/packet/compression.go
@@ -56,6 +56,9 @@ var (
 	}
 )
 
+// maxDecompressedLen is the maximum size of a decompressed packet.
+const maxDecompressedLen = 1024 * 1024 * 8 // 8 MB
+
 // EncodeCompression ...
 func (nopCompression) EncodeCompression() uint16 {
 	return CompressionAlgorithmNone
@@ -114,7 +117,7 @@ func (flateCompression) Decompress(compressed []byte) ([]byte, error) {
 
 	// Guess an uncompressed size of 2*len(compressed).
 	decompressed := bytes.NewBuffer(make([]byte, 0, len(compressed)*2))
-	if _, err := io.Copy(decompressed, c); err != nil {
+	if _, err := io.Copy(decompressed, io.LimitReader(c, maxDecompressedLen)); err != nil {
 		return nil, fmt.Errorf("decompress flate: %w", err)
 	}
 	return decompressed.Bytes(), nil

--- a/minecraft/protocol/packet/decoder.go
+++ b/minecraft/protocol/packet/decoder.go
@@ -21,8 +21,9 @@ type Decoder struct {
 	// NewDecoder implements the packetReader interface.
 	pr packetReader
 
-	decompress bool
-	encrypt    *encrypt
+	decompress         bool
+	maxDecompressedLen int
+	encrypt            *encrypt
 
 	checkPacketLimit bool
 }
@@ -56,8 +57,9 @@ func (decoder *Decoder) EnableEncryption(keyBytes [32]byte) {
 }
 
 // EnableCompression enables compression for the Decoder.
-func (decoder *Decoder) EnableCompression() {
+func (decoder *Decoder) EnableCompression(maxDecompressedLen int) {
 	decoder.decompress = true
+	decoder.maxDecompressedLen = maxDecompressedLen
 }
 
 // DisableBatchPacketLimit disables the check that limits the number of packets allowed in a single packet
@@ -112,7 +114,7 @@ func (decoder *Decoder) Decode() (packets [][]byte, err error) {
 			if !ok {
 				return nil, fmt.Errorf("decompress batch: unknown compression algorithm %v", data[0])
 			}
-			data, err = compression.Decompress(data[1:])
+			data, err = compression.Decompress(data[1:], decoder.maxDecompressedLen)
 			if err != nil {
 				return nil, fmt.Errorf("decompress batch: %w", err)
 			}


### PR DESCRIPTION
- zlib (based on the deflate algorithm) can achieve compression ratios of over 1000x
- snappy usually compresses data to about half or a third of its original size

so, decompression bomb attacks typically only happen with deflate-based compression.