### PR TITLE
Export ParsePongData, to be used by importing projects.

### DIFF
--- a/minecraft/server_status_provider.go
+++ b/minecraft/server_status_provider.go
@@ -111,7 +111,7 @@ func (f *ForeignStatusProvider) update() {
 				continue
 			}
 			f.mu.Lock()
-			f.status = parsePongData(data)
+			f.status = ParsePongData(data)
 			f.mu.Unlock()
 		case <-f.closed:
 			return
@@ -119,8 +119,8 @@ func (f *ForeignStatusProvider) update() {
 	}
 }
 
-// parsePongData parses the unconnected pong data passed into the relevant fields of a ServerStatus struct.
-func parsePongData(pong []byte) ServerStatus {
+// ParsePongData parses the unconnected pong data passed into the relevant fields of a ServerStatus struct.
+func ParsePongData(pong []byte) ServerStatus {
 	frag := splitPong(string(pong))
 	if len(frag) < 7 {
 		return ServerStatus{ServerName: "Invalid pong data"}


### PR DESCRIPTION
I use this in my vanilla-proxy repo, and I created a fork to do this with but would like to not have to have it in my fork.

For example, I use it to ping the downstream server to see if it is online:
```go
res, err := raknet.Ping(arg.Config.Connection.RemoteAddress)
if err != nil {
	// Server prob not online, retrying
	log.Logger.Warn("Failed to ping server, retrying in 5 seconds", "error", err)
	time.Sleep(time.Second * 5)
	arg.Start(h)
	return nil
}
// Server is online, parse data
status := minecraft.ParsePongData(res)
log.Logger.Info("Server online", "name", status.ServerName, "motd", status.ServerSubName)
p, err := minecraft.NewForeignStatusProvider(arg.Config.Connection.RemoteAddress)
if err != nil {
	return fmt.Errorf("failed to create foreign status provider: %w", err)
}
```