### PR TITLE
fix: login/request.go: add chain length check.

### DIFF
--- a/minecraft/protocol/login/request.go
+++ b/minecraft/protocol/login/request.go
@@ -271,6 +271,9 @@ func decodeChain(buf *bytes.Buffer) (chain, error) {
 	if err := binary.Read(buf, binary.LittleEndian, &chainLength); err != nil {
 		return nil, fmt.Errorf("read chain length: %w", err)
 	}
+	if chainLength <= 0 {
+		return nil, fmt.Errorf("invalid chain length: %d", chainLength)
+	}
 	chainData := buf.Next(int(chainLength))
 
 	request := &request{}


### PR DESCRIPTION
The listener may panic if the client send an incorrect chain length:
```
panic: runtime error: slice bounds out of range [:-16711932]

goroutine 1399 [running]:
bytes.(*Buffer).Next(...)
	sdk/go1.24.1/src/bytes/buffer.go:346
github.com/sandertv/gophertunnel/minecraft/protocol/login.decodeChain(0xc0380c71d0)
	gophertunnel/minecraft/protocol/login/request.go:274 +0x1d3
github.com/sandertv/gophertunnel/minecraft/protocol/login.parseLoginRequest({0xc037de9e4c, 0x4, 0x4})
	gophertunnel/minecraft/protocol/login/request.go:143 +0x85
github.com/sandertv/gophertunnel/minecraft/protocol/login.Parse({_, _, _})
	gophertunnel/minecraft/protocol/login/request.go:62 +0xfe
github.com/sandertv/gophertunnel/minecraft.(*Conn).handleLogin(0xc044038b08, 0xc037787780)
	gophertunnel/minecraft/conn.go:778 +0x20c
github.com/sandertv/gophertunnel/minecraft.(*Conn).handlePacket(0xc044038b08, {0x16727a8, 0xc037787780})
	gophertunnel/minecraft/conn.go:654 +0x2aa
github.com/sandertv/gophertunnel/minecraft.(*Conn).handleMultiple(0xc044038b08, {0xc03be68450?, 0xc037de9e40?, 0xc0380c7140?})
	gophertunnel/minecraft/conn.go:636 +0x85
github.com/sandertv/gophertunnel/minecraft.(*Conn).handle(0xc044038b08, 0xa?)
	gophertunnel/minecraft/conn.go:622 +0xb6
github.com/sandertv/gophertunnel/minecraft.(*Conn).receive(0xc044038b08, {0xc037ddf501?, 0x13eb1c0?, 0x0?})
	gophertunnel/minecraft/conn.go:610 +0x17f
github.com/sandertv/gophertunnel/minecraft.(*Listener).handleConn(0xc001d7e000, 0xc044038b08)
	gophertunnel/minecraft/listener.go:324 +0x165
created by github.com/sandertv/gophertunnel/minecraft.(*Listener).createConn in goroutine 31
	gophertunnel/minecraft/listener.go:292 +0x4ed

```