### PR TITLE
fill RequestChunkRadius MaxChunkRadius properly

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -1245,7 +1245,7 @@ func (conn *Conn) handleItemRegistry(pk *packet.ItemRegistry) error {
 		}
 	}
 
-	_ = conn.WritePacket(&packet.RequestChunkRadius{ChunkRadius: 16})
+	_ = conn.WritePacket(&packet.RequestChunkRadius{ChunkRadius: 16, MaxChunkRadius: 16})
 	conn.expect(packet.IDChunkRadiusUpdated, packet.IDPlayStatus)
 	return nil
 }

--- a/minecraft/example_dial_test.go
+++ b/minecraft/example_dial_test.go
@@ -46,7 +46,7 @@ func ExampleDial() {
 
 		// Write a packet to the connection: Similarly to ReadPacket, WritePacket will (only) return an error
 		// if the connection is closed.
-		p := &packet.RequestChunkRadius{ChunkRadius: 32}
+		p := &packet.RequestChunkRadius{ChunkRadius: 32, MaxChunkRadius: 32}
 		if err := conn.WritePacket(p); err != nil {
 			break
 		}


### PR DESCRIPTION
before: 
```
Kicked by server, message=handle *packet.ChunkRadiusUpdated: expected chunk radius of at least 1, got 0
```
after: join properly

[from allay](https://github.com/AllayMC/Allay/blob/eeccdc64e6f83347c6ed8b0782ef29a5471dc3ea/server/src/main/java/org/allaymc/server/network/processor/impl/ingame/RequestChunkRadiusPacketProcessor.java#L14)