### PR TITLE
feat: allow passing http client to realms client

### DIFF
--- a/minecraft/realms/realms.go
+++ b/minecraft/realms/realms.go
@@ -14,14 +14,19 @@ import (
 
 // Client is an instance of the realms api with a token.
 type Client struct {
-	tokenSrc oauth2.TokenSource
-	xblToken *auth.XBLToken
+	tokenSrc   oauth2.TokenSource
+	xblToken   *auth.XBLToken
+	httpClient *http.Client
 }
 
 // NewClient returns a new Client instance with the supplied token source for authentication.
-func NewClient(src oauth2.TokenSource) *Client {
+func NewClient(src oauth2.TokenSource, client *http.Client) *Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	return &Client{
-		tokenSrc: src,
+		tokenSrc:   src,
+		httpClient: client,
 	}
 }
 
@@ -166,7 +171,7 @@ func (r *Client) request(ctx context.Context, path string) (body []byte, status 
 	}
 	xbl.SetAuthHeader(req)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := r.httpClient.Do(req)
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
Necessary when having to use proxies for http request for cases like running gophertunnel on a vps