### PR TITLE
Fix p256 key encoding

### DIFF
--- a/minecraft/auth/xbox.go
+++ b/minecraft/auth/xbox.go
@@ -198,11 +198,9 @@ func sign(request *http.Request, body []byte, key *ecdsa.PrivateKey) {
 	// Sign the checksum produced, and combine the 'r' and 's' into a single signature.
 	// Encode r and s as 32-byte, zero-padded big-endian values so the P-256 signature is always exactly 64 bytes long.
 	r, s, _ := ecdsa.Sign(rand.Reader, key, hash.Sum(nil))
-	r32 := make([]byte, 32)
-	s32 := make([]byte, 32)
-	r.FillBytes(r32)
-	s.FillBytes(s32)
-	signature := append(r32, s32...)
+	signature := make([]byte, 64)
+	r.FillBytes(signature[:32])
+	s.FillBytes(signature[32:])
 
 	// The signature begins with 12 bytes, the first being the signature policy version (0, 0, 0, 1) again,
 	// and the other 8 the timestamp again.


### PR DESCRIPTION
This fixes the "403 forbidden" error by fixing a few places where we were we were sending an invalid signature to xbox.

# Context

basically big.Int.Bytes() uses minimal encoding which strips leading 0 bytes and when using .Bytes() on r, s, x, y, we can get a value which is less than 32 bytes. this causes the xbox api to return a 403 forbidden error.

https://datatracker.ietf.org/doc/html/rfc7518#section-3.4

https://docs.rs/ecdsa/latest/ecdsa/struct.Signature.html
> For example, in a curve with a 256-bit modulus like NIST P-256 or secp256k1, r and s will both be > 32-bytes and serialized as big endian, resulting in a signature with a total of 64-bytes.

also it fixes another potential encoding issue which was appending query params to the request url incorrectly, missing the ?, it was not causing any immediate issues because none of the urls we have use query params

# Reproduce
```go
func main() {
	src := tokenSource()
	tok, err := src.Token()
	if err != nil {
		panic(err)
	}

	xblToken, err := auth.RequestXBLToken(context.Background(), tok, "https://multiplayer.minecraft.net/")
	if err != nil {
		panic(err)
	}
        fmt.Println("successfully generated xbl token", xblToken")
}
```

## Reproduce with sign
https://github.com/Sandertv/gophertunnel/blob/d6ce91a211a4b3c572ad882960ae05f6aa635d8c/minecraft/auth/xbox.go#L167

Change the sign function to this, it forces generating a key with 31 bytes which guarantees a 403 forbidden response from xbox
```go
func sign(request *http.Request, body []byte, key *ecdsa.PrivateKey) {
	currentTime := windowsTimestamp()
	hash := sha256.New()

	// Signature policy version (0, 0, 0, 1) + 0 byte.
	buf := bytes.NewBuffer([]byte{0, 0, 0, 1, 0})
	// Timestamp + 0 byte.
	_ = binary.Write(buf, binary.BigEndian, currentTime)
	buf.Write([]byte{0})
	hash.Write(buf.Bytes())

	// HTTP method, generally POST + 0 byte.
	hash.Write([]byte("POST"))
	hash.Write([]byte{0})
	// Request uri path + raw query + 0 byte.
	hash.Write([]byte(request.URL.Path + request.URL.RawQuery))
	hash.Write([]byte{0})

	// Authorization header if present, otherwise an empty string + 0 byte.
	hash.Write([]byte(request.Header.Get("Authorization")))
	hash.Write([]byte{0})

	// Body data (only up to a certain limit, but this limit is practically never reached) + 0 byte.
	hash.Write(body)
	hash.Write([]byte{0})

	// Sign the checksum produced, and combine the 'r' and 's' into a single signature.
	// r, s, _ := ecdsa.Sign(rand.Reader, key, hash.Sum(nil))

// start changes
	digest := hash.Sum(nil)
	var r, s *big.Int
	for {
		rr, ss, _ := ecdsa.Sign(rand.Reader, key, digest)
		r, s = rr, ss
		if len(r.Bytes()) < 32 || len(s.Bytes()) < 32 {
			fmt.Printf("Found short signature! r=%d, s=%d\n", len(r.Bytes()), len(s.Bytes()))
			break
		}
	}

	rBytes := r.Bytes()
	sBytes := s.Bytes()

	fmt.Println("lengths", len(rBytes), len(sBytes))
// end changes
	signature := append(rBytes, sBytes...)

	// The signature begins with 12 bytes, the first being the signature policy version (0, 0, 0, 1) again,
	// and the other 8 the timestamp again.
	buf = bytes.NewBuffer([]byte{0, 0, 0, 1})
	_ = binary.Write(buf, binary.BigEndian, currentTime)

	// Append the signature to the other 12 bytes, and encode the signature with standard base64 encoding.
	sig := append(buf.Bytes(), signature...)
	request.Header.Set("Signature", base64.StdEncoding.EncodeToString(sig))
}
```

## Reproduce with RequestXblToken
```go
func RequestXBLToken(ctx context.Context, liveToken *oauth2.Token, relyingParty string) (*XBLToken, error) {
	if !liveToken.Valid() {
		return nil, fmt.Errorf("live token is no longer valid")
	}
	c := &http.Client{
		Transport: &http.Transport{
			TLSClientConfig: &tls.Config{
				Renegotiation:      tls.RenegotiateOnceAsClient,
				InsecureSkipVerify: true,
			},
		},
	}
	defer c.CloseIdleConnections()

	// We first generate an ECDSA private key which will be used to provide a 'ProofKey' to each of the
	// requests, and to sign these requests.
	// key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
	// if err != nil {
	// 	return nil, fmt.Errorf("generating ECDSA key: %w", err)
	// }

	var key *ecdsa.PrivateKey
	for {
		k, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
		if len(k.PublicKey.X.Bytes()) < 32 {
			key = k
			fmt.Printf("[device] found short X coord: X=%d, Y=%d\n", len(k.PublicKey.X.Bytes()), len(k.PublicKey.Y.Bytes()))
			break
		}
	}


	deviceToken, err := obtainDeviceToken(ctx, c, key)
	if err != nil {
		return nil, err
	}
	return obtainXBLToken(ctx, c, key, liveToken, deviceToken, relyingParty)
}
```

this bug happened in the codebase because we hired the h1b @cqdetdev 