### PR TITLE
fix: reading manifest fails if there are trailing comments

### DIFF
--- a/minecraft/resource/pack.go
+++ b/minecraft/resource/pack.go
@@ -5,14 +5,15 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/muhammadmuzzammil1998/jsonc"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
+	"github.com/muhammadmuzzammil1998/jsonc"
 )
 
 // Pack is a container of a resource pack parsed from a directory or a .zip archive (or .mcpack). It holds
@@ -420,7 +421,7 @@ func readManifest(path string) (*Manifest, error) {
 	return manifest, nil
 }
 
-// unmarshalJSON unmarshals JSON data into a struct and removes trailing comments.
+// unmarshalJSON unmarshals JSON data while removing trailing comments.
 func unmarshalJSON(data []byte, v any) error {
 	clean := jsonc.ToJSON([]byte(data))
 	if idx := bytes.LastIndex(clean, []byte("}")); idx != -1 {

--- a/minecraft/resource/pack.go
+++ b/minecraft/resource/pack.go
@@ -409,7 +409,7 @@ func readManifest(path string) (*Manifest, error) {
 		return nil, fmt.Errorf("read manifest file: %w", err)
 	}
 	manifest := &Manifest{}
-	if err := jsonc.Unmarshal(allData, manifest); err != nil {
+	if err := unmarshalJSON(allData, manifest); err != nil {
 		return nil, fmt.Errorf("decode manifest JSON: %w (data: %v)", err, string(allData))
 	}
 
@@ -418,4 +418,13 @@ func readManifest(path string) (*Manifest, error) {
 	}
 
 	return manifest, nil
+}
+
+// unmarshalJSON unmarshals JSON data into a struct and removes trailing comments.
+func unmarshalJSON(data []byte, v any) error {
+	clean := jsonc.ToJSON([]byte(data))
+	if idx := bytes.LastIndex(clean, []byte("}")); idx != -1 {
+		clean = clean[:idx+1]
+	}
+	return jsonc.Unmarshal(clean, v)
 }


### PR DESCRIPTION
jsonc.unmarshal only strips comments that are in the json block, not any that come after
<img width="986" height="701" alt="image" src="https://github.com/user-attachments/assets/41bf9dbd-7993-494e-aecf-5b0d694b9a2f" />
