### PR TITLE
Allow both semver and array in pack manifest versions and add missing Metadata field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/sandertv/gophertunnel
 go 1.24
 
 require (
+	github.com/df-mc/jsonc v1.0.2
 	github.com/go-gl/mathgl v1.1.0
 	github.com/go-jose/go-jose/v4 v4.1.0
 	github.com/golang/snappy v0.0.4
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.17.11
-	github.com/df-mc/jsonc v1.0.2
 	github.com/pelletier/go-toml v1.9.5
 	github.com/sandertv/go-raknet v1.14.3-0.20250305181847-6af3e95113d6
 	golang.org/x/net v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/df-mc/jsonc v1.0.1 h1:5P6TvCSr1de9wm13Q/CWOmiqbNRo1dJqZvjP65anMTo=
-github.com/df-mc/jsonc v1.0.1/go.mod h1:M4L42tg8sc0TQ7JWwqYe0mSi5BwWrcZ3XBCfL3gZsNg=
+github.com/df-mc/jsonc v1.0.2 h1:IOyY9mMtpHxOPnOnD5hQ7xmOpbGCCJYs8Mn6UmbKTik=
 github.com/df-mc/jsonc v1.0.2/go.mod h1:+Q++JuCE9IKiP8v7sWImdf/RjQX0nfXyfX6PdfTTmc4=
 github.com/go-gl/mathgl v1.1.0 h1:0lzZ+rntPX3/oGrDzYGdowSLC2ky8Osirvf5uAwfIEA=
 github.com/go-gl/mathgl v1.1.0/go.mod h1:yhpkQzEiH9yPyxDUGzkmgScbaBVlhC06qodikEM0ZwQ=


### PR DESCRIPTION
Closes #344 
<img width="1512" height="687" alt="image" src="https://github.com/user-attachments/assets/8e7801fa-8626-46fa-bfaf-a60451cc2ab9" />
