### PR TITLE
minecraft/protocol: Fix the marshal of debug drawer packet

### DIFF
--- a/minecraft/protocol/io.go
+++ b/minecraft/protocol/io.go
@@ -61,6 +61,7 @@ type IO interface {
 	AbilityValue(x *any)
 	Bitset(x *Bitset, size int)
 	PackSetting(x *PackSetting)
+	ShapeData(x *ShapeData)
 
 	ShieldID() int32
 	UnknownEnumOption(value any, enum string)

--- a/minecraft/protocol/packet/debug_drawer.go
+++ b/minecraft/protocol/packet/debug_drawer.go
@@ -1,73 +1,13 @@
 package packet
 
-import (
-	"github.com/go-gl/mathgl/mgl32"
-	"image/color"
-	"github.com/sandertv/gophertunnel/minecraft/protocol"
-)
-
-const (
-	ScriptDebugShapeLine = iota
-	ScriptDebugShapeBox
-	ScriptDebugShapeSphere
-	ScriptDebugShapeCircle
-	ScriptDebugShapeText
-	ScriptDebugShapeArrow
-)
-
-// DebugDrawerShape defines a single debug shape to be rendered on the client.
-// Each shape has a unique NetworkID and a set of optional parameters depending on its type.
-type DebugDrawerShape struct {
-	// NetworkID is the network ID of the shape.
-	NetworkID uint64
-	// Type is the type of the shape.
-	Type protocol.Optional[uint8]
-	// Location is the location of the shape.
-	Location protocol.Optional[mgl32.Vec3]
-	// Scale is the scale of the shape.
-	Scale protocol.Optional[float32]
-	// Rotation is the rotation of the shape.
-	Rotation protocol.Optional[mgl32.Vec3]
-	// TotalTimeLeft is the total time left of the shape.
-	TotalTimeLeft protocol.Optional[float32]
-	// Colour is the ARGB colour of the shape.
-	Colour protocol.Optional[color.RGBA]
-	// Text is the text of the shape.
-	Text protocol.Optional[string]
-	// BoxBound is the box bound of the shape.
-	BoxBound protocol.Optional[mgl32.Vec3]
-	// LineEndLocation is the line end location of the shape.
-	LineEndLocation protocol.Optional[mgl32.Vec3]
-	// ArrowHeadLength is the arrow head length of the shape.
-	ArrowHeadLength protocol.Optional[float32]
-	// ArrowHeadRadius is the arrow head radius of the shape.
-	ArrowHeadRadius protocol.Optional[float32]
-	// Segments is the number of segments of the shape.
-	Segments protocol.Optional[byte]
-}
-
-func (x *DebugDrawerShape) Marshal(io protocol.IO) {
-	io.Varuint64(&x.NetworkID)
-	protocol.OptionalFunc(io, &x.Type, io.Uint8)
-	protocol.OptionalFunc(io, &x.Location, io.Vec3)
-	protocol.OptionalFunc(io, &x.Scale, io.Float32)
-	protocol.OptionalFunc(io, &x.Rotation, io.Vec3)
-	protocol.OptionalFunc(io, &x.TotalTimeLeft, io.Float32)
-	protocol.OptionalFunc(io, &x.Colour, io.BEARGB)
-	protocol.OptionalFunc(io, &x.Text, io.String)
-	protocol.OptionalFunc(io, &x.BoxBound, io.Vec3)
-	protocol.OptionalFunc(io, &x.LineEndLocation, io.Vec3)
-	protocol.OptionalFunc(io, &x.ArrowHeadLength, io.Float32)
-	protocol.OptionalFunc(io, &x.ArrowHeadRadius, io.Float32)
-	protocol.OptionalFunc(io, &x.Segments, io.Uint8)
-}
+import "github.com/sandertv/gophertunnel/minecraft/protocol"
 
 // DebugDrawer is a packet sent by the server to instruct the client to render
 // one or more debug shapes. Each packet fully replaces any previously rendered shapes.
 // To remove a shape, omit it from the next packet's Shapes slice.
 type DebugDrawer struct {
 	// Shapes is a list of shapes to draw on the client-side.
-	Shapes []DebugDrawerShape
+	Shapes []protocol.DebugDrawerShape
 }
 
 // ID ...

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -631,6 +631,17 @@ func (r *Reader) PackSetting(x *PackSetting) {
 	}
 }
 
+// ShapeData reads a ShapeData's type from the reader.
+func (r *Reader) ShapeData(x *ShapeData) {
+	var shapeDataType uint32
+	r.Varuint32(&shapeDataType)
+	if !lookupShapeData(shapeDataType, x) {
+		r.UnknownEnumOption(shapeDataType, "debug shape data type")
+		return
+	}
+	(*x).Marshal(r)
+}
+
 // SliceLimit checks if the value passed is lower than the limit passed. If
 // not, the Reader panics.
 func (r *Reader) SliceLimit(value uint32, max uint32) {

--- a/minecraft/protocol/shape.go
+++ b/minecraft/protocol/shape.go
@@ -1,0 +1,182 @@
+package protocol
+
+import (
+	"github.com/go-gl/mathgl/mgl32"
+	"image/color"
+)
+
+const (
+	ShapeDataLast = iota
+	ShapeDataArrow
+	ShapeDataText
+	ShapeDataBox
+	ShapeDataLine
+	ShapeDataSphere
+)
+
+// lookupShapeData looks up an ShapeData matching the shape data type passed.
+// False is returned if no such shape data exists.
+func lookupShapeData(shapeDataType uint32, x *ShapeData) bool {
+	switch shapeDataType {
+	case ShapeDataLast:
+		*x = &LastShape{}
+	case ShapeDataArrow:
+		*x = &ArrowShape{}
+	case ShapeDataText:
+		*x = &TextShape{}
+	case ShapeDataBox:
+		*x = &BoxShape{}
+	case ShapeDataLine:
+		*x = &LineShape{}
+	case ShapeDataSphere:
+		*x = &SphereShape{}
+	default:
+		return false
+	}
+	return true
+}
+
+// lookupShapeDataType looks up a debug shape type that matches the ShapeData passed.
+func lookupShapeDataType(x ShapeData, shapeDataType *uint32) bool {
+	switch x.(type) {
+	case *LastShape:
+		*shapeDataType = ShapeDataLast
+	case *ArrowShape:
+		*shapeDataType = ShapeDataArrow
+	case *TextShape:
+		*shapeDataType = ShapeDataText
+	case *BoxShape:
+		*shapeDataType = ShapeDataBox
+	case *LineShape:
+		*shapeDataType = ShapeDataLine
+	case *SphereShape:
+		*shapeDataType = ShapeDataSphere
+	default:
+		return false
+	}
+	return true
+}
+
+// ShapeData represents an object that holds data specific to a debug shape.
+// The data it holds depends on the type.
+type ShapeData interface {
+	// Marshal encodes/decodes a serialised debug shape data object.
+	Marshal(r IO)
+}
+
+// LastShape points to using the last shape settings.
+// If no shape has ever been set, then use the default one.
+type LastShape struct{}
+
+// Marshal ...
+func (shape *LastShape) Marshal(io IO) {}
+
+// LineShape represents a line debug shape.
+type LineShape struct {
+	// LineEndLocation is the line end location of the shape.
+	LineEndLocation mgl32.Vec3
+}
+
+// Marshal ...
+func (shape *LineShape) Marshal(io IO) {
+	io.Vec3(&shape.LineEndLocation)
+}
+
+// TextShape represents a text debug shape.
+type TextShape struct {
+	// Text is the text of the debug text shape.
+	Text string
+}
+
+// Marshal ...
+func (shape *TextShape) Marshal(io IO) {
+	io.String(&shape.Text)
+}
+
+// BoxShape represents a box debug shape.
+type BoxShape struct {
+	// BoxBound is the box bound of the shape.
+	BoxBound mgl32.Vec3
+}
+
+// Marshal ...
+func (shape *BoxShape) Marshal(io IO) {
+	io.Vec3(&shape.BoxBound)
+}
+
+// SphereShape represents a circle or sphere debug shape.
+type SphereShape struct {
+	// Segments is the segments that used for the debug circle or sphere.
+	Segments byte
+}
+
+// Marshal ...
+func (shape *SphereShape) Marshal(io IO) {
+	io.Uint8(&shape.Segments)
+}
+
+// ArrowShape represents an arrow debug shape.
+type ArrowShape struct {
+	// ArrowEndLocation is the arrow end location of the shape.
+	ArrowEndLocation Optional[mgl32.Vec3]
+	// ArrowHeadLength is the arrow head length of the shape.
+	ArrowHeadLength Optional[float32]
+	// ArrowHeadRadius is the arrow head radius of the shape.
+	ArrowHeadRadius Optional[float32]
+	// Segments is the segments that used for the debug arrow's head.
+	Segments Optional[byte]
+}
+
+// Marshal ...
+func (shape *ArrowShape) Marshal(io IO) {
+	OptionalFunc(io, &shape.ArrowEndLocation, io.Vec3)
+	OptionalFunc(io, &shape.ArrowHeadLength, io.Float32)
+	OptionalFunc(io, &shape.ArrowHeadRadius, io.Float32)
+	OptionalFunc(io, &shape.Segments, io.Uint8)
+}
+
+const (
+	DebugDrawerShapeLine = iota
+	DebugDrawerShapeBox
+	DebugDrawerShapeSphere
+	DebugDrawerShapeCircle
+	DebugDrawerShapeText
+	DebugDrawerShapeArrow
+)
+
+// DebugDrawerShape defines a single debug shape to be rendered on the client.
+// Each shape has a unique NetworkID and a set of optional parameters depending on its type.
+type DebugDrawerShape struct {
+	// NetworkID is the network ID of the shape.
+	NetworkID uint64
+	// DimensionID is the dimension ID where the shape is rendered.
+	DimensionID int32
+	// Type is the type of the shape.
+	// If not set, the set shape will be cleared.
+	Type Optional[uint8]
+	// Location is the location of the shape.
+	Location Optional[mgl32.Vec3]
+	// Scale is the scale of the shape.
+	Scale Optional[float32]
+	// Rotation is the rotation of the shape.
+	Rotation Optional[mgl32.Vec3]
+	// TotalTimeLeft is the total time left of the shape.
+	TotalTimeLeft Optional[float32]
+	// Colour is the ARGB colour of the shape.
+	Colour Optional[color.RGBA]
+	// ExtraShapeData holding data specific to the type of shape (such as text string for the text shape).
+	ExtraShapeData ShapeData
+}
+
+// Marshal ...
+func (x *DebugDrawerShape) Marshal(io IO) {
+	io.Varuint64(&x.NetworkID)
+	OptionalFunc(io, &x.Type, io.Uint8)
+	OptionalFunc(io, &x.Location, io.Vec3)
+	OptionalFunc(io, &x.Scale, io.Float32)
+	OptionalFunc(io, &x.Rotation, io.Vec3)
+	OptionalFunc(io, &x.TotalTimeLeft, io.Float32)
+	OptionalFunc(io, &x.Colour, io.BEARGB)
+	io.Varint32(&x.DimensionID)
+	io.ShapeData(&x.ExtraShapeData)
+}

--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -517,6 +517,16 @@ func (w *Writer) PackSetting(x *PackSetting) {
 	}
 }
 
+// ShapeData writes a ShapeData to the writer.
+func (w *Writer) ShapeData(x *ShapeData) {
+	var shapeDataType uint32
+	if !lookupShapeDataType(*x, &shapeDataType) {
+		w.UnknownEnumOption(fmt.Sprintf("%T", *x), "debug shape data type")
+	}
+	w.Varuint32(&shapeDataType)
+	(*x).Marshal(w)
+}
+
 // Varint64 writes an int64 as 1-10 bytes to the underlying buffer.
 func (w *Writer) Varint64(x *int64) {
 	u := *x


### PR DESCRIPTION
For possible references, please refer to [DebugDrawerPacket.json](https://github.com/Mojang/bedrock-protocol-docs/blob/main/json/DebugDrawerPacket.json).

But unfortunately, the official documentation ([DebugDrawerPacket.html](https://github.com/Mojang/bedrock-protocol-docs/blob/main/docs/DebugDrawerPacket.html)) does not provide a complete description of it.
Even [DebugDrawerPacket.json](https://github.com/Mojang/bedrock-protocol-docs/blob/main/json/DebugDrawerPacket.json) itself is incomplete.

I controlled the variable a great many times in **Minecraft** and finally fixed this packet.
Good luck to me, this time I didn't use **IDA**, which reduced the mental torture it caused me.