### PR TITLE
minecraft/protocol: Support 1.21.124

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -728,11 +728,6 @@ func (conn *Conn) handleRequestNetworkSettings(pk *packet.RequestNetworkSettings
 			break
 		}
 	}
-	if !found && protocol.CurrentProtocol == 860 && pk.ClientProtocol == 859 {
-		conn.proto = DefaultProtocol
-		conn.pool = conn.proto.Packets(true)
-		found = true
-	}
 	if !found {
 		status := packet.PlayStatusLoginFailedClient
 		if pk.ClientProtocol > protocol.CurrentProtocol {


### PR DESCRIPTION
accept proto versions 859 & 860 as only StartGamePacket block palette hash has changed