### PR TITLE
mineraft/protocol: Simple event packet can send from client

### DIFF
--- a/minecraft/protocol/packet/pool.go
+++ b/minecraft/protocol/packet/pool.go
@@ -298,6 +298,7 @@ func init() {
 		IDContainerClose:                  func() Packet { return &ContainerClose{} },
 		IDAdventureSettings:               func() Packet { return &AdventureSettings{} },
 		IDSetPlayerGameType:               func() Packet { return &SetPlayerGameType{} },
+		IDSimpleEvent:                     func() Packet { return &SimpleEvent{} },
 		IDMapInfoRequest:                  func() Packet { return &MapInfoRequest{} },
 		IDRequestChunkRadius:              func() Packet { return &RequestChunkRadius{} },
 		IDBossEvent:                       func() Packet { return &BossEvent{} },

--- a/minecraft/protocol/packet/simple_event.go
+++ b/minecraft/protocol/packet/simple_event.go
@@ -10,8 +10,9 @@ const (
 	SimpleEventUnlockWorldTemplateSettings
 )
 
-// SimpleEvent is sent by the server to send a 'simple event' to the client, meaning an event without any
-// additional event data. The event is typically used by the client for telemetry.
+// SimpleEvent is used for enabling or disabling commands and for unlocking world template settings
+// (both unlocking UI buttons on client and the actual setting on the server).
+// This is fired from the client to the server and a SetCommandsEnabled is sent back when enabling commands.
 type SimpleEvent struct {
 	// EventType is the type of the event to be called. It is one of the constants that may be found above.
 	EventType uint16


### PR DESCRIPTION
When change the default game type to creative mode, this packet will send from mc to the server.
```go
packet.SimpleEvent{
    EventType: packet.SimpleEventCommandsEnabled
}
```
However, the client packet pool not include this packet, then the connection between mc and server will lost due to unknown packet error.

-----

I fix this and change the description of this packet.
The description is the same to mojang's docs.
> <img width="1843" height="896" alt="image" src="https://github.com/user-attachments/assets/b3e6b2ba-bc2d-4e96-a878-e39c82c0f8f7" />

-----

However, I don't know when is the time that the server send this packet.
If the server will never send that, then this packet should remove from the server packet pool.
