### PR TITLE
perf: reduce Item and ItemInstance decode allocations

### DIFF
--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -427,10 +427,8 @@ func (r *Reader) ItemInstance(i *ItemInstance) {
 	if x.NetworkID == 0 {
 		// The item was air, so there is no more data we should read for the item instance. After all, air
 		// items aren't really anything.
-		x.MetadataValue, x.Count, x.BlockRuntimeID = 0, 0, 0
-		x.NBTData = nil
-		x.CanBePlacedOn, x.CanBreak = nil, nil
-		i.StackNetworkID = 0
+		x.MetadataValue, x.Count, x.BlockRuntimeID, i.StackNetworkID = 0, 0, 0, 0
+		x.NBTData, x.CanBePlacedOn, x.CanBreak = nil, nil, nil
 		return
 	}
 
@@ -490,8 +488,7 @@ func (r *Reader) Item(x *ItemStack) {
 		// The item was air, so there is no more data we should read for the item instance. After all, air
 		// items aren't really anything.
 		x.MetadataValue, x.Count, x.BlockRuntimeID = 0, 0, 0
-		x.NBTData = nil
-		x.CanBePlacedOn, x.CanBreak = nil, nil
+		x.NBTData, x.CanBePlacedOn, x.CanBreak = nil, nil, nil
 		return
 	}
 


### PR DESCRIPTION
- Avoid allocating fresh map[string]any for empty/absent item NBT
- Clear stale ItemInstance.StackNetworkID when hasNetID is false
- UUID decode uses io.ReadFull and avoids heap allocations. This one is a micro opt but imo worth keeping

Makes a meaningful difference to reduce allocations in CraftingData decode

```
// ReadFull reads exactly len(buf) bytes from r into buf.
// It returns the number of bytes copied and an error if fewer bytes were read.
// The error is EOF only if no bytes were read.
// If an EOF happens after reading some but not all the bytes,
// ReadFull returns [ErrUnexpectedEOF].
// On return, n == len(buf) if and only if err == nil.
// If r returns an error having read at least len(buf) bytes, the error is dropped.
```

## Benchstat summary
<img width="994" height="576" alt="image" src="https://github.com/user-attachments/assets/3479663b-92dd-4ccc-b174-7d40c4e768eb" />

## Benchstat results
<img width="1658" height="876" alt="image" src="https://github.com/user-attachments/assets/bb5a0aa3-8ffb-4f1b-b74f-0ee851453c92" />
