### PR TITLE
fix: incorrect enum value logging

### DIFF
--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -574,7 +574,7 @@ func (r *Reader) EventType(x *Event) {
 func (r *Reader) EventOrdinal(x *Event) {
 	var ordinal uint32
 	if !lookupEventOrdinal(*x, &ordinal) {
-		r.UnknownEnumOption(fmt.Sprintf("%T", x), "event packet event ordinal")
+		r.UnknownEnumOption(*x, "event packet event ordinal")
 		return
 	}
 	r.Varuint32(&ordinal)
@@ -693,7 +693,7 @@ func (r *Reader) ShieldID() int32 {
 
 // UnknownEnumOption panics with an unknown enum option error.
 func (r *Reader) UnknownEnumOption(value any, enum string) {
-	r.panicf("unknown value '%v' for enum type '%v'", value, enum)
+	r.panicf("unknown value '%#v' for enum type '%v'", value, enum)
 }
 
 // InvalidValue panics with an error indicating that the value passed is not valid for a specific field.

--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -442,7 +442,7 @@ func (w *Writer) Recipe(x *Recipe) {
 func (w *Writer) EventType(x *Event) {
 	var t int32
 	if !lookupEventType(*x, &t) {
-		w.UnknownEnumOption(fmt.Sprintf("%T", x), "event packet event type")
+		w.UnknownEnumOption(*x, "event packet event type")
 	}
 	w.Varint32(&t)
 }
@@ -451,7 +451,7 @@ func (w *Writer) EventType(x *Event) {
 func (w *Writer) EventOrdinal(x *Event) {
 	var ordinal uint32
 	if !lookupEventOrdinal(*x, &ordinal) {
-		w.UnknownEnumOption(fmt.Sprintf("%T", x), "event packet event ordinal")
+		w.UnknownEnumOption(*x, "event packet event ordinal")
 		return
 	}
 	w.Varuint32(&ordinal)
@@ -612,7 +612,7 @@ func (w *Writer) ShieldID() int32 {
 
 // UnknownEnumOption panics with an unknown enum option error.
 func (w *Writer) UnknownEnumOption(value any, enum string) {
-	w.panicf("unknown value '%v' for enum type '%v'", value, enum)
+	w.panicf("unknown value '%#v' for enum type '%v'", value, enum)
 }
 
 // InvalidValue panics with an invalid value error.


### PR DESCRIPTION
this logs the actual value instead of the type
previous log was not helpful:
<img width="953" height="36" alt="image" src="https://github.com/user-attachments/assets/52cb5a5a-b73f-4c84-b266-d9544255a660" />
