### PR TITLE
Performance: Avoid holding sendMu during Flush network writes

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -506,8 +506,10 @@ func (conn *Conn) Flush() error {
 		conn.sendMu.Unlock()
 		return nil
 	}
+
+	// Detach the current buffer and swap in the spare so writers can keep appending while we encode,
+	// without reallocating bufferedSend.
 	toSend := conn.bufferedSend
-	// Swap buffers so writers can keep appending while we encode, without reallocating bufferedSend.
 	conn.bufferedSend = conn.bufferedSendSpare[:0]
 	conn.bufferedSendSpare = nil
 	conn.sendMu.Unlock()


### PR DESCRIPTION
This PR removes a major send-path bottleneck by ensuring we don’t hold the hot sendMu while doing network writes. Flush() now quickly snapshots and clears the queued batch, then performs the expensive enc.Encode(...) write outside the queue lock. This dramatically reduces mutex contention under load (especially when the write path stalls/backpressures), improving throughput and reducing latency spikes.

Benchmarks show ~32%–99% throughput improvements, depending on workload: ~32% for WritePacket() under simulated slow writes, and up to ~99% for raw Write() when the write path stalls/backpressures.

Also fixes a bug in WritePacket which would appear when ConvertFromLatest returns multiple packets, it was reusing the same buffer across all packets.

# Benchmarks
## Results
<img width="750" height="278" alt="image" src="https://github.com/user-attachments/assets/66997d61-1d15-4112-9dde-a86c0afd264a" />

## Code
```go
package minecraft

import (
	"io"
	"log/slog"
	"net"
	"sync"
	"sync/atomic"
	"testing"
	"time"

	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
)

type dummyAddr string

func (a dummyAddr) Network() string { return "bench" }
func (a dummyAddr) String() string  { return string(a) }

// discardConn is a net.Conn that discards writes and optionally sleeps to simulate
// a slow network write path (kernel buffers, encryption overhead, etc.).
type discardConn struct {
	writeDelay time.Duration
	closed     atomic.Bool
}

func (c *discardConn) Read(_ []byte) (int, error) { return 0, io.EOF }
func (c *discardConn) Write(p []byte) (int, error) {
	if c.writeDelay > 0 {
		time.Sleep(c.writeDelay)
	}
	return len(p), nil
}
func (c *discardConn) Close() error { c.closed.Store(true); return nil }
func (c *discardConn) LocalAddr() net.Addr {
	return dummyAddr("local")
}
func (c *discardConn) RemoteAddr() net.Addr {
	return dummyAddr("remote")
}
func (c *discardConn) SetDeadline(time.Time) error      { return nil }
func (c *discardConn) SetReadDeadline(time.Time) error  { return nil }
func (c *discardConn) SetWriteDeadline(time.Time) error { return nil }

func newBenchConn(writeDelay time.Duration) *Conn {
	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
	return newConn(&discardConn{writeDelay: writeDelay}, nil, log, DefaultProtocol, 0, true)
}

func BenchmarkConnWrite_FlushParallel(b *testing.B) {
	cases := []struct {
		name  string
		delay time.Duration
	}{
		{name: "NoDelay", delay: 0},
		{name: "WriteDelay50us", delay: 50 * time.Microsecond},
	}
	for _, tc := range cases {
		b.Run(tc.name, func(b *testing.B) {
			conn := newBenchConn(tc.delay)
			payload := make([]byte, 512)

			var stop atomic.Bool
			var wg sync.WaitGroup
			wg.Add(1)
			go func() {
				defer wg.Done()
				for !stop.Load() {
					_ = conn.Flush()
				}
			}()

			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					_, _ = conn.Write(payload)
				}
			})
			b.StopTimer()

			stop.Store(true)
			wg.Wait()
			_ = conn.Flush()
		})
	}
}

func BenchmarkConnWritePacket_FlushParallel(b *testing.B) {
	cases := []struct {
		name  string
		delay time.Duration
	}{
		{name: "NoDelay", delay: 0},
		{name: "WriteDelay50us", delay: 50 * time.Microsecond},
	}
	for _, tc := range cases {
		b.Run(tc.name, func(b *testing.B) {
			conn := newBenchConn(tc.delay)

			var stop atomic.Bool
			var wg sync.WaitGroup
			wg.Add(1)
			go func() {
				defer wg.Done()
				for !stop.Load() {
					_ = conn.Flush()
				}
			}()

			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				pk := &packet.Text{
					TextType: packet.TextTypeChat,
					Message:  "hi",
				}
				for pb.Next() {
					_ = conn.WritePacket(pk)
				}
			})
			b.StopTimer()

			stop.Store(true)
			wg.Wait()
			_ = conn.Flush()
		})
	}
}
```