### PR TITLE
Fix client data always generates lower-hex device id for any OS

### DIFF
--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -441,8 +441,7 @@ func defaultClientData(address, username string, d *login.ClientData) {
 		d.ClientRandomID = rand.Int63()
 	}
 	if d.DeviceID == "" {
-		// This can be parsed as DeviceIDFormatLowerHexString and is standard on `most` devices including Android.
-		d.DeviceID = login.DeviceID(strings.ReplaceAll(uuid.NewString(), "-", ""))
+		d.DeviceID = d.ExpectedDeviceIDFormat().Generate()
 	}
 	if d.LanguageCode == "" {
 		d.LanguageCode = "en_GB"


### PR DESCRIPTION
- Added DeviceIDFormat.Generate() so each format knows how to produce a correctly shaped random ID.
- Replaced the hardcoded lower-hex generation with d.ExpectedDeviceIDFormat().Generate(), which picks the right format based on the device's OS.
- Improved / cleaned up documentation