### PR TITLE
service/token_source.go: Validate XSTS display claims before returning token

### DIFF
--- a/minecraft/service/token_source.go
+++ b/minecraft/service/token_source.go
@@ -113,6 +113,9 @@ func (x xblTokenSource) Token() (xsapi.Token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("request xsts token for %q: %w", x.relyingParty, err)
 	}
+	if len(xsts.AuthorizationToken.DisplayClaims.UserInfo) == 0 {
+		return nil, fmt.Errorf("request xsts token for %q: no user info in display claims", x.relyingParty)
+	}
 	return &xstsToken{xsts}, nil
 }
 


### PR DESCRIPTION
Fixed a panic caused by accessing an empty `UserInfo` slice in `xstsToken` methods (`String`, `DisplayClaims`). `xblTokenSource.Token()` now validates the slice, returning an error if it is empty.