### PR TITLE
Optimize Item and ItemInstance encoding

### DIFF
--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-gl/mathgl/mgl32"
 	"github.com/google/uuid"
+	"github.com/sandertv/gophertunnel/minecraft/internal"
 	"github.com/sandertv/gophertunnel/minecraft/nbt"
 )
 
@@ -343,8 +344,13 @@ func (w *Writer) ItemInstance(i *ItemInstance) {
 	}
 
 	w.Varint32(&x.BlockRuntimeID)
+	buf := internal.BufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer func() {
+		buf.Reset()
+		internal.BufferPool.Put(buf)
+	}()
 
-	buf := new(bytes.Buffer)
 	bufWriter := NewWriter(buf, w.shieldID)
 
 	var length int16
@@ -383,8 +389,13 @@ func (w *Writer) Item(x *ItemStack) {
 	w.Varuint32(&x.MetadataValue)
 	w.Varint32(&x.BlockRuntimeID)
 
-	var extraData []byte
-	buf := bytes.NewBuffer(extraData)
+	buf := internal.BufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer func() {
+		buf.Reset()
+		internal.BufferPool.Put(buf)
+	}()
+
 	bufWriter := NewWriter(buf, w.shieldID)
 
 	var length int16
@@ -407,7 +418,7 @@ func (w *Writer) Item(x *ItemStack) {
 		bufWriter.Int64(&blockingTick)
 	}
 
-	extraData = buf.Bytes()
+	extraData := buf.Bytes()
 	w.ByteSlice(&extraData)
 }
 


### PR DESCRIPTION
Optimize `Item` and `ItemInstance` encoding by reusing temporary buffers from `internal.BufferPool` instead of allocating a new `bytes.Buffer` on every encode.

## Benchmark results

Benchstat (`n=20`, `-benchtime=1s`) for `BenchmarkItemInstanceEncoding`:

- `sec/op`: `845.1ns -> 735.8ns` (**-12.94%**, ~1.15x faster)
- `B/op`: `856 -> 360` (**-57.94%**, ~2.38x less)
- `allocs/op`: `38 -> 34` (**-10.53%**, ~1.12x fewer)

## Benchmark code
```go
package protocol

import (
	"bytes"
	"testing"

	"github.com/sandertv/gophertunnel/minecraft/nbt"
)

var (
	benchBytesLenSink     int
)

func BenchmarkItemInstanceEncoding(b *testing.B) {
	const shieldID int32 = 5_000_000

	item := benchmarkItemInstance()
	size := len(encodeItemInstanceLegacy(item, shieldID))

	b.Run("before_legacy", func(b *testing.B) {
		b.ReportAllocs()
		b.SetBytes(int64(size))

		var out bytes.Buffer
		w := &Writer{w: &out, shieldID: shieldID}

		for i := 0; i < b.N; i++ {
			out.Reset()
			legacyWriteItemInstance(w, &item)
			benchBytesLenSink = out.Len()
		}
	})

	b.Run("after_current", func(b *testing.B) {
		b.ReportAllocs()
		b.SetBytes(int64(size))

		var out bytes.Buffer
		w := &Writer{w: &out, shieldID: shieldID}

		for i := 0; i < b.N; i++ {
			out.Reset()
			w.ItemInstance(&item)
			benchBytesLenSink = out.Len()
		}
	})
}

func benchmarkItemInstance() ItemInstance {
	return ItemInstance{
		StackNetworkID: 42,
		Stack: ItemStack{
			ItemType: ItemType{
				NetworkID:     355,
				MetadataValue: 7,
			},
			BlockRuntimeID: 12_345,
			Count:          64,
			NBTData: map[string]any{
				"display": map[string]any{
					"Name": "benchmark_item",
				},
				"Damage":      int16(123),
				"Unbreakable": byte(1),
			},
			CanBePlacedOn: []string{
				"minecraft:stone",
				"minecraft:dirt",
				"minecraft:deepslate",
			},
			CanBreak: []string{
				"minecraft:oak_log",
				"minecraft:diamond_ore",
			},
		},
	}
}

func encodeItemInstanceLegacy(item ItemInstance, shieldID int32) []byte {
	var out bytes.Buffer
	w := &Writer{w: &out, shieldID: shieldID}
	legacyWriteItemInstance(w, &item)
	return append([]byte(nil), out.Bytes()...)
}

func legacyWriteItemInstance(w *Writer, i *ItemInstance) {
	x := &i.Stack
	w.Varint32(&x.NetworkID)
	if x.NetworkID == 0 {
		return
	}

	w.Uint16(&x.Count)
	w.Varuint32(&x.MetadataValue)

	hasNetID := i.StackNetworkID != 0
	w.Bool(&hasNetID)

	if hasNetID {
		w.Varint32(&i.StackNetworkID)
	}

	w.Varint32(&x.BlockRuntimeID)

	buf := new(bytes.Buffer)
	bufWriter := NewWriter(buf, w.shieldID)

	var length int16
	if len(x.NBTData) != 0 {
		length = int16(-1)
		version := uint8(1)

		bufWriter.Int16(&length)
		bufWriter.Uint8(&version)
		bufWriter.NBT(&x.NBTData, nbt.LittleEndian)
	} else {
		bufWriter.Int16(&length)
	}

	FuncSliceUint32Length(bufWriter, &x.CanBePlacedOn, bufWriter.StringUTF)
	FuncSliceUint32Length(bufWriter, &x.CanBreak, bufWriter.StringUTF)

	if x.NetworkID == bufWriter.shieldID {
		var blockingTick int64
		bufWriter.Int64(&blockingTick)
	}

	b := buf.Bytes()
	w.ByteSlice(&b)
}

```