### PR TITLE
minecraft/conn.go: Re-check deferred packets on expect() to prevent handshake deadlock

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -1444,9 +1444,33 @@ func (conn *Conn) enableEncryption(clientPublicKey *ecdsa.PublicKey) error {
 	return nil
 }
 
-// expect sets the packet IDs that are next expected to arrive.
+// expect sets the packet IDs that are next expected to arrive and re-checks
+// any deferred packets against the new expected set. This prevents a deadlock
+// when a packet arrives before its ID is added to the expected set.
 func (conn *Conn) expect(packetIDs ...uint32) {
 	conn.expectedIDs.Store(packetIDs)
+	conn.handleDeferredPackets()
+}
+
+// handleDeferredPackets passes all currently deferred packets back through
+// handle(). Packets that now match expectedIDs are processed; the rest are
+// re-deferred by handle() automatically.
+func (conn *Conn) handleDeferredPackets() {
+	conn.deferredPacketMu.Lock()
+	if len(conn.deferredPackets) == 0 {
+		conn.deferredPacketMu.Unlock()
+		return
+	}
+	deferred := conn.deferredPackets
+	conn.deferredPackets = conn.deferredPackets[len(deferred):]
+	conn.deferredPacketMu.Unlock()
+
+	for _, pkData := range deferred {
+		if err := conn.handle(pkData); err != nil {
+			_ = conn.close(err)
+			return
+		}
+	}
 }
 
 func (conn *Conn) close(cause error) error {


### PR DESCRIPTION
When a server sends `ResourcePacksInfo` before `PlayStatus(LoginSuccess)`,
the packet gets deferred because its ID isn't in `expectedIDs` yet. When
`PlayStatus` later arrives and `expect(IDResourcePacksInfo)` is called,
the already-deferred packet is never re-checked, causing `Dial()` to
deadlock waiting for a packet that's already been received and discarded.

This adds `handleDeferredPackets()` which is called from `expect()` to
re-process deferred packets against the updated expected set. Packets
that still don't match are re-deferred by `handle()` automatically.

Observed against several public Bedrock servers (intermittent, depends
on packet arrival order which varies per connection).
