### PR TITLE
protocol/shape.go: Add uint8 type to DebugDrawerShape constants

### DIFF
--- a/minecraft/protocol/shape.go
+++ b/minecraft/protocol/shape.go
@@ -137,7 +137,7 @@ func (shape *ArrowShape) Marshal(io IO) {
 }
 
 const (
-	DebugDrawerShapeLine = iota
+	DebugDrawerShapeLine uint8 = iota
 	DebugDrawerShapeBox
 	DebugDrawerShapeSphere
 	DebugDrawerShapeCircle


### PR DESCRIPTION
Added `uint8` type to `DebugDrawerShape` constants to match the underlying type used by the shape.