### PR TITLE
minecraft/protocol: Use EntityMetadata type instead of map[uint32]any

### DIFF
--- a/minecraft/protocol/io.go
+++ b/minecraft/protocol/io.go
@@ -47,7 +47,7 @@ type IO interface {
 	ARGB(x *color.RGBA)
 	BEARGB(x *color.RGBA)
 	VarRGBA(x *color.RGBA)
-	EntityMetadata(x *map[uint32]any)
+	EntityMetadata(x *EntityMetadata)
 	Item(x *ItemStack)
 	ItemInstance(i *ItemInstance)
 	ItemDescriptorCount(i *ItemDescriptorCount)

--- a/minecraft/protocol/packet/add_actor.go
+++ b/minecraft/protocol/packet/add_actor.go
@@ -42,7 +42,7 @@ type AddActor struct {
 	// EntityMetadata is a map of entity metadata, which includes flags and data properties that alter in
 	// particular the way the entity looks. Flags include ones such as 'on fire' and 'sprinting'.
 	// The metadata values are indexed by their property key.
-	EntityMetadata map[uint32]any
+	EntityMetadata protocol.EntityMetadata
 	// EntityProperties is a list of properties that the entity inhibits. These properties define and alter specific
 	// attributes of the entity.
 	EntityProperties protocol.EntityProperties

--- a/minecraft/protocol/packet/add_item_actor.go
+++ b/minecraft/protocol/packet/add_item_actor.go
@@ -27,7 +27,7 @@ type AddItemActor struct {
 	// EntityMetadata is a map of entity metadata, which includes flags and data properties that alter in
 	// particular the way the entity looks. Flags include ones such as 'on fire' and 'sprinting'.
 	// The metadata values are indexed by their property key.
-	EntityMetadata map[uint32]any
+	EntityMetadata protocol.EntityMetadata
 	// FromFishing specifies if the item was obtained by fishing it up using a fishing rod. It is not clear
 	// why the client needs to know this.
 	FromFishing bool

--- a/minecraft/protocol/packet/add_player.go
+++ b/minecraft/protocol/packet/add_player.go
@@ -46,7 +46,7 @@ type AddPlayer struct {
 	// EntityMetadata is a map of entity metadata, which includes flags and data properties that alter in
 	// particular the way the player looks. Flags include ones such as 'on fire' and 'sprinting'.
 	// The metadata values are indexed by their property key.
-	EntityMetadata map[uint32]any
+	EntityMetadata protocol.EntityMetadata
 	// EntityProperties is a list of properties that the entity inhibits. These properties define and alter specific
 	// attributes of the entity.
 	EntityProperties protocol.EntityProperties

--- a/minecraft/protocol/packet/set_actor_data.go
+++ b/minecraft/protocol/packet/set_actor_data.go
@@ -13,7 +13,7 @@ type SetActorData struct {
 	// EntityMetadata is a map of entity metadata, which includes flags and data properties that alter in
 	// particular the way the entity looks. Flags include ones such as 'on fire' and 'sprinting'.
 	// The metadata values are indexed by their property key.
-	EntityMetadata map[uint32]any
+	EntityMetadata protocol.EntityMetadata
 	// EntityProperties is a list of properties that the entity inhibits. These properties define and alter specific
 	// attributes of the entity.
 	EntityProperties protocol.EntityProperties

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -332,8 +332,8 @@ func (r *Reader) GameRuleLegacy(x *GameRule) {
 }
 
 // EntityMetadata reads an entity metadata map from the underlying buffer into map x.
-func (r *Reader) EntityMetadata(x *map[uint32]any) {
-	*x = map[uint32]any{}
+func (r *Reader) EntityMetadata(x *EntityMetadata) {
+	*x = EntityMetadata{}
 
 	var count uint32
 	r.Varuint32(&count)

--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -231,7 +231,7 @@ func (w *Writer) GameRuleLegacy(x *GameRule) {
 }
 
 // EntityMetadata writes an entity metadata map x to the underlying buffer.
-func (w *Writer) EntityMetadata(x *map[uint32]any) {
+func (w *Writer) EntityMetadata(x *EntityMetadata) {
 	l := uint32(len(*x))
 	w.Varuint32(&l)
 


### PR DESCRIPTION
Uses the `EntityMetadata` type instead of `map[uint32]any` in packets and IO methods. This allows helper methods like `SetFlag` and `UnsetFlag` to be used directly on packet fields without a type conversion.