### PR TITLE
Add missing realm fields and custom NetworkProtocol type

### DIFF
--- a/minecraft/realms/network_protocol.go
+++ b/minecraft/realms/network_protocol.go
@@ -2,7 +2,7 @@ package realms
 
 import "strings"
 
-// NetworkProtocol is the protocol hint returned by the Realms API for a join target.
+// NetworkProtocol is the protocol type returned by the Realms API used to connect to a realm.
 type NetworkProtocol string
 
 const (
@@ -11,12 +11,12 @@ const (
 	NetworkProtocolNetherNetJSONRPC NetworkProtocol = "NETHERNET_JSONRPC"
 )
 
-// ParseNetworkProtocol normalizes a Realm network protocol string.
+// ParseNetworkProtocol converts a network protocol string to a NetworkProtocol value.
 func ParseNetworkProtocol(protocol string) NetworkProtocol {
 	return NetworkProtocol(strings.ToUpper(strings.TrimSpace(protocol)))
 }
 
-// Valid reports whether the protocol is one of the known Realms values.
+// Valid reports whether the protocol is one of the known constants.
 func (p NetworkProtocol) Valid() bool {
 	switch ParseNetworkProtocol(string(p)) {
 	case NetworkProtocolDefault, NetworkProtocolNetherNet, NetworkProtocolNetherNetJSONRPC:

--- a/minecraft/realms/network_protocol.go
+++ b/minecraft/realms/network_protocol.go
@@ -1,0 +1,27 @@
+package realms
+
+import "strings"
+
+// NetworkProtocol is the protocol hint returned by the Realms API for a join target.
+type NetworkProtocol string
+
+const (
+	NetworkProtocolDefault          NetworkProtocol = "DEFAULT"
+	NetworkProtocolNetherNet        NetworkProtocol = "NETHERNET"
+	NetworkProtocolNetherNetJSONRPC NetworkProtocol = "NETHERNET_JSONRPC"
+)
+
+// ParseNetworkProtocol normalizes a Realm network protocol string.
+func ParseNetworkProtocol(protocol string) NetworkProtocol {
+	return NetworkProtocol(strings.ToUpper(strings.TrimSpace(protocol)))
+}
+
+// Valid reports whether the protocol is one of the known Realms values.
+func (p NetworkProtocol) Valid() bool {
+	switch ParseNetworkProtocol(string(p)) {
+	case NetworkProtocolDefault, NetworkProtocolNetherNet, NetworkProtocolNetherNetJSONRPC:
+		return true
+	default:
+		return false
+	}
+}

--- a/minecraft/realms/realms.go
+++ b/minecraft/realms/realms.go
@@ -113,8 +113,13 @@ type Realm struct {
 // RealmAddress contains the address returned by the Realms join endpoint along
 // with the signalling protocol used for connecting to it.
 type RealmAddress struct {
-	NetworkProtocol string `json:"networkProtocol"`
-	Address         string `json:"address"`
+	Address           string `json:"address"`
+	NetworkProtocol   string `json:"networkProtocol"`
+	PendingUpdate     bool   `json:"pendingUpdate"`
+	SessionRegionData struct {
+		RegionName     string `json:"regionName"`
+		ServiceQuality int    `json:"serviceQuality"`
+	} `json:"sessionRegionData"`
 }
 
 // Address requests the address and protocol used to connect to this realm.


### PR DESCRIPTION
- Adds missing fields to RealmAddress struct
- Adds a typed realms.NetworkProtocol type to define constants for known realm network protocols and add validator method. This will be required when we want to do a full nethernet implementation, makes it easier to catch when mojang adds a new protocol type, and prevents downstream code from defining duplicate constants