### PR TITLE
Persist BlockingTick on shield ItemStacks

### DIFF
--- a/minecraft/protocol/item.go
+++ b/minecraft/protocol/item.go
@@ -36,6 +36,8 @@ type ItemStack struct {
 	CanBreak []string
 	// HasNetworkID ...
 	HasNetworkID bool
+	// BlockingTick is the tick at which a shield started blocking. It is only used for shield items.
+	BlockingTick int64
 }
 
 // ItemType represents a consistent combination of network ID and metadata value of an item. It cannot usually

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -467,8 +467,7 @@ func (r *Reader) ItemInstance(i *ItemInstance) {
 	FuncSliceUint32Length(bufReader, &x.CanBreak, bufReader.StringUTF)
 
 	if x.NetworkID == bufReader.shieldID {
-		var blockingTick int64
-		bufReader.Int64(&blockingTick)
+		bufReader.Int64(&x.BlockingTick)
 	}
 }
 
@@ -517,8 +516,7 @@ func (r *Reader) Item(x *ItemStack) {
 	FuncSliceUint32Length(bufReader, &x.CanBreak, bufReader.StringUTF)
 
 	if x.NetworkID == bufReader.shieldID {
-		var blockingTick int64
-		bufReader.Int64(&blockingTick)
+		bufReader.Int64(&x.BlockingTick)
 	}
 }
 

--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -362,8 +362,7 @@ func (w *Writer) ItemInstance(i *ItemInstance) {
 	FuncSliceUint32Length(bufWriter, &x.CanBreak, bufWriter.StringUTF)
 
 	if x.NetworkID == bufWriter.shieldID {
-		var blockingTick int64
-		bufWriter.Int64(&blockingTick)
+		bufWriter.Int64(&x.BlockingTick)
 	}
 
 	b := buf.Bytes()
@@ -407,8 +406,7 @@ func (w *Writer) Item(x *ItemStack) {
 	FuncSliceUint32Length(bufWriter, &x.CanBreak, bufWriter.StringUTF)
 
 	if x.NetworkID == bufWriter.shieldID {
-		var blockingTick int64
-		bufWriter.Int64(&blockingTick)
+		bufWriter.Int64(&x.BlockingTick)
 	}
 
 	extraData := buf.Bytes()


### PR DESCRIPTION
## Summary
  - Adds a `BlockingTick int64` field to `protocol.ItemStack` so the shield's blocking-tick value is preserved
  across decode/encode instead of being read-and-discarded / written-as-zero.
  - Wires the new field through both `Item` and `ItemInstance` paths in `reader.go` and `writer.go`.

  Fixes #304. When a proxy round-trips an `InventoryContent` for the off-hand slot, the shield's `blockingTick` was
   being silently zeroed, which left the client stuck in the blocking pose / desynced raise animation. Storing the
  field on `ItemStack` is the minimal fix suggested by @Happy2018new and confirmed by @JAMadison in the issue
  thread.
