### PR TITLE
Reject malformed oversized packet batches during decode

### DIFF
--- a/minecraft/protocol/packet/decoder.go
+++ b/minecraft/protocol/packet/decoder.go
@@ -66,6 +66,7 @@ func NewDecoder(reader io.Reader) *Decoder {
 	return &Decoder{
 		r:                 reader,
 		buf:               make([]byte, 1024*1024*3),
+		header:            batch,
 		checkPacketLimit:  true,
 		disableEncryption: disableEncryption,
 	}
@@ -138,6 +139,9 @@ func (decoder *Decoder) Decode() (packets [][]byte, err error) {
 	}
 
 	if decoder.decompress {
+		if len(data) == 0 {
+			return nil, fmt.Errorf("decompress batch: missing compression algorithm")
+		}
 		if data[0] == 0xff {
 			data = data[1:]
 		} else {
@@ -161,10 +165,16 @@ func (decoder *Decoder) Decode() (packets [][]byte, err error) {
 		if err := protocol.Varuint32(b, &length); err != nil {
 			return nil, fmt.Errorf("decode batch: read packet length: %w", err)
 		}
+		if length == 0 {
+			return nil, fmt.Errorf("decode batch: empty packet")
+		}
+		if length > uint32(b.Len()) {
+			return nil, fmt.Errorf("decode batch: packet length %v exceeds remaining %v", length, b.Len())
+		}
+		if len(packets) >= maximumInBatch && decoder.checkPacketLimit {
+			return nil, fmt.Errorf("decode batch: number of packets exceeds max=%v", maximumInBatch)
+		}
 		packets = append(packets, b.Next(int(length)))
-	}
-	if len(packets) > maximumInBatch && decoder.checkPacketLimit {
-		return nil, fmt.Errorf("decode batch: number of packets %v exceeds max=%v", len(packets), maximumInBatch)
 	}
 	return packets, nil
 }


### PR DESCRIPTION
## Summary

  - Reject empty inner packets while splitting a batch.
  - Reject truncated inner packet lengths before reading packet data.
  - Enforce the max packet count during batch splitting instead of after collecting the full slice.
  - Reject compressed batches that are missing the compression algorithm byte.
  - Preserve the batch header in the generic `io.Reader` decoder path.

  This prevents malformed compressed batches from forcing the decoder to allocate a large packet slice before returning
  an error.

## Testing
A vanilla dragonfly server and a patched dragonfly server (using this commit) were both tested with exploit. The vanilla server increased in RAM by 3gb after 16777216 packets were sent. The patched one did not. Both servers kicked the user.