### PR TITLE
Remove scalar reads/writes from heap allocations

### DIFF
--- a/minecraft/nbt/encoding_big_endian.go
+++ b/minecraft/nbt/encoding_big_endian.go
@@ -12,8 +12,9 @@ type bigEndian struct{}
 
 // WriteInt16 ...
 func (bigEndian) WriteInt16(w *offsetWriter, x int16) error {
-	b := *(*[2]byte)(unsafe.Pointer(&x))
-	if _, err := w.Write(b[:]); err != nil {
+	b := w.buf[:2]
+	binary.BigEndian.PutUint16(b, uint16(x))
+	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteInt16", Off: w.off}
 	}
 	return nil
@@ -21,8 +22,9 @@ func (bigEndian) WriteInt16(w *offsetWriter, x int16) error {
 
 // WriteInt32 ...
 func (bigEndian) WriteInt32(w *offsetWriter, x int32) error {
-	b := *(*[4]byte)(unsafe.Pointer(&x))
-	if _, err := w.Write(b[:]); err != nil {
+	b := w.buf[:4]
+	binary.BigEndian.PutUint32(b, uint32(x))
+	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteInt32", Off: w.off}
 	}
 	return nil
@@ -30,8 +32,9 @@ func (bigEndian) WriteInt32(w *offsetWriter, x int32) error {
 
 // WriteInt64 ...
 func (bigEndian) WriteInt64(w *offsetWriter, x int64) error {
-	b := *(*[8]byte)(unsafe.Pointer(&x))
-	if _, err := w.Write(b[:]); err != nil {
+	b := w.buf[:8]
+	binary.BigEndian.PutUint64(b, uint64(x))
+	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteInt64", Off: w.off}
 	}
 	return nil
@@ -39,8 +42,9 @@ func (bigEndian) WriteInt64(w *offsetWriter, x int64) error {
 
 // WriteFloat32 ...
 func (bigEndian) WriteFloat32(w *offsetWriter, x float32) error {
-	b := *(*[4]byte)(unsafe.Pointer(&x))
-	if _, err := w.Write(b[:]); err != nil {
+	b := w.buf[:4]
+	binary.BigEndian.PutUint32(b, math.Float32bits(x))
+	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteFloat32", Off: w.off}
 	}
 	return nil
@@ -48,8 +52,9 @@ func (bigEndian) WriteFloat32(w *offsetWriter, x float32) error {
 
 // WriteFloat64 ...
 func (bigEndian) WriteFloat64(w *offsetWriter, x float64) error {
-	b := *(*[8]byte)(unsafe.Pointer(&x))
-	if _, err := w.Write(b[:]); err != nil {
+	b := w.buf[:8]
+	binary.BigEndian.PutUint64(b, math.Float64bits(x))
+	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteFloat64", Off: w.off}
 	}
 	return nil
@@ -73,47 +78,47 @@ func (e bigEndian) WriteString(w *offsetWriter, x string) error {
 
 // Int16 ...
 func (bigEndian) Int16(r *offsetReader) (int16, error) {
-	b := make([]byte, 2)
+	b := r.buf[:2]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Int16"}
 	}
-	return *(*int16)(unsafe.Pointer(&b[0])), nil
+	return int16(binary.BigEndian.Uint16(b)), nil
 }
 
 // Int32 ...
 func (bigEndian) Int32(r *offsetReader) (int32, error) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Int32"}
 	}
-	return *(*int32)(unsafe.Pointer(&b[0])), nil
+	return int32(binary.BigEndian.Uint32(b)), nil
 }
 
 // Int64 ...
 func (bigEndian) Int64(r *offsetReader) (int64, error) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float64"}
 	}
-	return *(*int64)(unsafe.Pointer(&b[0])), nil
+	return int64(binary.BigEndian.Uint64(b)), nil
 }
 
 // Float32 ...
 func (bigEndian) Float32(r *offsetReader) (float32, error) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float32"}
 	}
-	return *(*float32)(unsafe.Pointer(&b[0])), nil
+	return math.Float32frombits(binary.BigEndian.Uint32(b)), nil
 }
 
 // Float64 ...
 func (bigEndian) Float64(r *offsetReader) (float64, error) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float64"}
 	}
-	return *(*float64)(unsafe.Pointer(&b[0])), nil
+	return math.Float64frombits(binary.BigEndian.Uint64(b)), nil
 }
 
 // String ...
@@ -165,7 +170,7 @@ type littleEndian struct{}
 
 // WriteInt16 ...
 func (littleEndian) WriteInt16(w *offsetWriter, x int16) error {
-	b := make([]byte, 2)
+	b := w.buf[:2]
 	binary.LittleEndian.PutUint16(b, uint16(x))
 	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteInt16", Off: w.off}
@@ -175,7 +180,7 @@ func (littleEndian) WriteInt16(w *offsetWriter, x int16) error {
 
 // WriteInt32 ...
 func (littleEndian) WriteInt32(w *offsetWriter, x int32) error {
-	b := make([]byte, 4)
+	b := w.buf[:4]
 	binary.LittleEndian.PutUint32(b, uint32(x))
 	if _, err := w.Write(b[:]); err != nil {
 		return FailedWriteError{Op: "WriteInt32", Off: w.off}
@@ -185,7 +190,7 @@ func (littleEndian) WriteInt32(w *offsetWriter, x int32) error {
 
 // WriteInt64 ...
 func (littleEndian) WriteInt64(w *offsetWriter, x int64) error {
-	b := make([]byte, 8)
+	b := w.buf[:8]
 	binary.LittleEndian.PutUint64(b, uint64(x))
 	if _, err := w.Write(b[:]); err != nil {
 		return FailedWriteError{Op: "WriteInt64", Off: w.off}
@@ -195,7 +200,7 @@ func (littleEndian) WriteInt64(w *offsetWriter, x int64) error {
 
 // WriteFloat32 ...
 func (littleEndian) WriteFloat32(w *offsetWriter, x float32) error {
-	b := make([]byte, 4)
+	b := w.buf[:4]
 	binary.LittleEndian.PutUint32(b, math.Float32bits(x))
 	if _, err := w.Write(b[:]); err != nil {
 		return FailedWriteError{Op: "WriteFloat32", Off: w.off}
@@ -205,7 +210,7 @@ func (littleEndian) WriteFloat32(w *offsetWriter, x float32) error {
 
 // WriteFloat64 ...
 func (littleEndian) WriteFloat64(w *offsetWriter, x float64) error {
-	b := make([]byte, 8)
+	b := w.buf[:8]
 	binary.LittleEndian.PutUint64(b, math.Float64bits(x))
 	if _, err := w.Write(b[:]); err != nil {
 		return FailedWriteError{Op: "WriteFloat64", Off: w.off}
@@ -231,7 +236,7 @@ func (e littleEndian) WriteString(w *offsetWriter, x string) error {
 
 // Int16 ...
 func (littleEndian) Int16(r *offsetReader) (int16, error) {
-	b := make([]byte, 2)
+	b := r.buf[:2]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Int16"}
 	}
@@ -240,7 +245,7 @@ func (littleEndian) Int16(r *offsetReader) (int16, error) {
 
 // Int32 ...
 func (littleEndian) Int32(r *offsetReader) (int32, error) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Int32"}
 	}
@@ -249,7 +254,7 @@ func (littleEndian) Int32(r *offsetReader) (int32, error) {
 
 // Int64 ...
 func (littleEndian) Int64(r *offsetReader) (int64, error) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float64"}
 	}
@@ -258,7 +263,7 @@ func (littleEndian) Int64(r *offsetReader) (int64, error) {
 
 // Float32 ...
 func (littleEndian) Float32(r *offsetReader) (float32, error) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float32"}
 	}
@@ -267,7 +272,7 @@ func (littleEndian) Float32(r *offsetReader) (float32, error) {
 
 // Float64 ...
 func (littleEndian) Float64(r *offsetReader) (float64, error) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float64"}
 	}

--- a/minecraft/nbt/encoding_little_endian.go
+++ b/minecraft/nbt/encoding_little_endian.go
@@ -12,8 +12,9 @@ type littleEndian struct{}
 
 // WriteInt16 ...
 func (littleEndian) WriteInt16(w *offsetWriter, x int16) error {
-	b := *(*[2]byte)(unsafe.Pointer(&x))
-	if _, err := w.Write(b[:]); err != nil {
+	b := w.buf[:2]
+	binary.LittleEndian.PutUint16(b, uint16(x))
+	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteInt16", Off: w.off}
 	}
 	return nil
@@ -21,8 +22,9 @@ func (littleEndian) WriteInt16(w *offsetWriter, x int16) error {
 
 // WriteInt32 ...
 func (littleEndian) WriteInt32(w *offsetWriter, x int32) error {
-	b := *(*[4]byte)(unsafe.Pointer(&x))
-	if _, err := w.Write(b[:]); err != nil {
+	b := w.buf[:4]
+	binary.LittleEndian.PutUint32(b, uint32(x))
+	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteInt32", Off: w.off}
 	}
 	return nil
@@ -30,8 +32,9 @@ func (littleEndian) WriteInt32(w *offsetWriter, x int32) error {
 
 // WriteInt64 ...
 func (littleEndian) WriteInt64(w *offsetWriter, x int64) error {
-	b := *(*[8]byte)(unsafe.Pointer(&x))
-	if _, err := w.Write(b[:]); err != nil {
+	b := w.buf[:8]
+	binary.LittleEndian.PutUint64(b, uint64(x))
+	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteInt64", Off: w.off}
 	}
 	return nil
@@ -39,8 +42,9 @@ func (littleEndian) WriteInt64(w *offsetWriter, x int64) error {
 
 // WriteFloat32 ...
 func (littleEndian) WriteFloat32(w *offsetWriter, x float32) error {
-	b := *(*[4]byte)(unsafe.Pointer(&x))
-	if _, err := w.Write(b[:]); err != nil {
+	b := w.buf[:4]
+	binary.LittleEndian.PutUint32(b, math.Float32bits(x))
+	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteFloat32", Off: w.off}
 	}
 	return nil
@@ -48,8 +52,9 @@ func (littleEndian) WriteFloat32(w *offsetWriter, x float32) error {
 
 // WriteFloat64 ...
 func (littleEndian) WriteFloat64(w *offsetWriter, x float64) error {
-	b := *(*[8]byte)(unsafe.Pointer(&x))
-	if _, err := w.Write(b[:]); err != nil {
+	b := w.buf[:8]
+	binary.LittleEndian.PutUint64(b, math.Float64bits(x))
+	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteFloat64", Off: w.off}
 	}
 	return nil
@@ -73,47 +78,47 @@ func (e littleEndian) WriteString(w *offsetWriter, x string) error {
 
 // Int16 ...
 func (littleEndian) Int16(r *offsetReader) (int16, error) {
-	b := make([]byte, 2)
+	b := r.buf[:2]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Int16"}
 	}
-	return *(*int16)(unsafe.Pointer(&b[0])), nil
+	return int16(binary.LittleEndian.Uint16(b)), nil
 }
 
 // Int32 ...
 func (littleEndian) Int32(r *offsetReader) (int32, error) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Int32"}
 	}
-	return *(*int32)(unsafe.Pointer(&b[0])), nil
+	return int32(binary.LittleEndian.Uint32(b)), nil
 }
 
 // Int64 ...
 func (littleEndian) Int64(r *offsetReader) (int64, error) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float64"}
 	}
-	return *(*int64)(unsafe.Pointer(&b[0])), nil
+	return int64(binary.LittleEndian.Uint64(b)), nil
 }
 
 // Float32 ...
 func (littleEndian) Float32(r *offsetReader) (float32, error) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float32"}
 	}
-	return *(*float32)(unsafe.Pointer(&b[0])), nil
+	return math.Float32frombits(binary.LittleEndian.Uint32(b)), nil
 }
 
 // Float64 ...
 func (littleEndian) Float64(r *offsetReader) (float64, error) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float64"}
 	}
-	return *(*float64)(unsafe.Pointer(&b[0])), nil
+	return math.Float64frombits(binary.LittleEndian.Uint64(b)), nil
 }
 
 // String ...
@@ -165,7 +170,7 @@ type bigEndian struct{}
 
 // WriteInt16 ...
 func (bigEndian) WriteInt16(w *offsetWriter, x int16) error {
-	b := make([]byte, 2)
+	b := w.buf[:2]
 	binary.BigEndian.PutUint16(b, uint16(x))
 	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteInt16", Off: w.off}
@@ -175,7 +180,7 @@ func (bigEndian) WriteInt16(w *offsetWriter, x int16) error {
 
 // WriteInt32 ...
 func (bigEndian) WriteInt32(w *offsetWriter, x int32) error {
-	b := make([]byte, 4)
+	b := w.buf[:4]
 	binary.BigEndian.PutUint32(b, uint32(x))
 	if _, err := w.Write(b[:]); err != nil {
 		return FailedWriteError{Op: "WriteInt32", Off: w.off}
@@ -185,7 +190,7 @@ func (bigEndian) WriteInt32(w *offsetWriter, x int32) error {
 
 // WriteInt64 ...
 func (bigEndian) WriteInt64(w *offsetWriter, x int64) error {
-	b := make([]byte, 8)
+	b := w.buf[:8]
 	binary.BigEndian.PutUint64(b, uint64(x))
 	if _, err := w.Write(b[:]); err != nil {
 		return FailedWriteError{Op: "WriteInt64", Off: w.off}
@@ -195,7 +200,7 @@ func (bigEndian) WriteInt64(w *offsetWriter, x int64) error {
 
 // WriteFloat32 ...
 func (bigEndian) WriteFloat32(w *offsetWriter, x float32) error {
-	b := make([]byte, 4)
+	b := w.buf[:4]
 	binary.BigEndian.PutUint32(b, math.Float32bits(x))
 	if _, err := w.Write(b[:]); err != nil {
 		return FailedWriteError{Op: "WriteFloat32", Off: w.off}
@@ -205,7 +210,7 @@ func (bigEndian) WriteFloat32(w *offsetWriter, x float32) error {
 
 // WriteFloat64 ...
 func (bigEndian) WriteFloat64(w *offsetWriter, x float64) error {
-	b := make([]byte, 8)
+	b := w.buf[:8]
 	binary.BigEndian.PutUint64(b, math.Float64bits(x))
 	if _, err := w.Write(b[:]); err != nil {
 		return FailedWriteError{Op: "WriteFloat64", Off: w.off}
@@ -231,7 +236,7 @@ func (e bigEndian) WriteString(w *offsetWriter, x string) error {
 
 // Int16 ...
 func (bigEndian) Int16(r *offsetReader) (int16, error) {
-	b := make([]byte, 2)
+	b := r.buf[:2]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Int16"}
 	}
@@ -240,7 +245,7 @@ func (bigEndian) Int16(r *offsetReader) (int16, error) {
 
 // Int32 ...
 func (bigEndian) Int32(r *offsetReader) (int32, error) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Int32"}
 	}
@@ -249,7 +254,7 @@ func (bigEndian) Int32(r *offsetReader) (int32, error) {
 
 // Int64 ...
 func (bigEndian) Int64(r *offsetReader) (int64, error) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float64"}
 	}
@@ -258,7 +263,7 @@ func (bigEndian) Int64(r *offsetReader) (int64, error) {
 
 // Float32 ...
 func (bigEndian) Float32(r *offsetReader) (float32, error) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float32"}
 	}
@@ -267,7 +272,7 @@ func (bigEndian) Float32(r *offsetReader) (float32, error) {
 
 // Float64 ...
 func (bigEndian) Float64(r *offsetReader) (float64, error) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.Read(b); err != nil {
 		return 0, BufferOverrunError{Op: "Float64"}
 	}

--- a/minecraft/nbt/reader.go
+++ b/minecraft/nbt/reader.go
@@ -9,6 +9,7 @@ import (
 type offsetReader struct {
 	io.Reader
 	off int64
+	buf [8]byte
 
 	// ReadByte is a function provided by offsetReader if the io.Reader does not implement io.ByteReader.
 	ReadByte func() (byte, error)

--- a/minecraft/nbt/writer.go
+++ b/minecraft/nbt/writer.go
@@ -7,6 +7,7 @@ import "io"
 type offsetWriter struct {
 	io.Writer
 	off int64
+	buf [8]byte
 
 	// WriteByte is a function implemented by offsetWriter if the io.Writer does not implement it itself.
 	WriteByte func(byte) error

--- a/minecraft/protocol/packet/decoder.go
+++ b/minecraft/protocol/packet/decoder.go
@@ -66,6 +66,7 @@ func NewDecoder(reader io.Reader) *Decoder {
 	return &Decoder{
 		r:                 reader,
 		buf:               make([]byte, 1024*1024*3),
+		header:            batch,
 		checkPacketLimit:  true,
 		disableEncryption: disableEncryption,
 	}
@@ -138,6 +139,9 @@ func (decoder *Decoder) Decode() (packets [][]byte, err error) {
 	}
 
 	if decoder.decompress {
+		if len(data) == 0 {
+			return nil, fmt.Errorf("decompress batch: missing compression algorithm")
+		}
 		if data[0] == 0xff {
 			data = data[1:]
 		} else {
@@ -161,10 +165,16 @@ func (decoder *Decoder) Decode() (packets [][]byte, err error) {
 		if err := protocol.Varuint32(b, &length); err != nil {
 			return nil, fmt.Errorf("decode batch: read packet length: %w", err)
 		}
+		if length == 0 {
+			return nil, fmt.Errorf("decode batch: empty packet")
+		}
+		if length > uint32(b.Len()) {
+			return nil, fmt.Errorf("decode batch: packet length %v exceeds remaining %v", length, b.Len())
+		}
+		if len(packets) >= maximumInBatch && decoder.checkPacketLimit {
+			return nil, fmt.Errorf("decode batch: number of packets exceeds max=%v", maximumInBatch)
+		}
 		packets = append(packets, b.Next(int(length)))
-	}
-	if len(packets) > maximumInBatch && decoder.checkPacketLimit {
-		return nil, fmt.Errorf("decode batch: number of packets %v exceeds max=%v", len(packets), maximumInBatch)
 	}
 	return packets, nil
 }

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -26,6 +26,7 @@ type Reader struct {
 	}
 	shieldID      int32
 	limitsEnabled bool
+	buf           [8]byte
 }
 
 // NewReader creates a new Reader using the io.ByteReader passed as underlying source to read bytes from.

--- a/minecraft/protocol/reader_big_endian.go
+++ b/minecraft/protocol/reader_big_endian.go
@@ -5,12 +5,11 @@ package protocol
 import (
 	"encoding/binary"
 	"math"
-	"unsafe"
 )
 
 // Uint16 reads a little endian uint16 from the underlying buffer.
 func (r *Reader) Uint16(x *uint16) {
-	b := make([]byte, 2)
+	b := r.buf[:2]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
@@ -19,7 +18,7 @@ func (r *Reader) Uint16(x *uint16) {
 
 // Int16 reads a little endian int16 from the underlying buffer.
 func (r *Reader) Int16(x *int16) {
-	b := make([]byte, 2)
+	b := r.buf[:2]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
@@ -28,7 +27,7 @@ func (r *Reader) Int16(x *int16) {
 
 // Uint32 reads a little endian uint32 from the underlying buffer.
 func (r *Reader) Uint32(x *uint32) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
@@ -37,7 +36,7 @@ func (r *Reader) Uint32(x *uint32) {
 
 // Int32 reads a little endian int32 from the underlying buffer.
 func (r *Reader) Int32(x *int32) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
@@ -46,16 +45,16 @@ func (r *Reader) Int32(x *int32) {
 
 // BEInt32 reads a big endian int32 from the underlying buffer.
 func (r *Reader) BEInt32(x *int32) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
-	*x = *(*int32)(unsafe.Pointer(&b[0]))
+	*x = int32(binary.BigEndian.Uint32(b))
 }
 
 // Uint64 reads a little endian uint64 from the underlying buffer.
 func (r *Reader) Uint64(x *uint64) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
@@ -64,7 +63,7 @@ func (r *Reader) Uint64(x *uint64) {
 
 // Int64 reads a little endian int64 from the underlying buffer.
 func (r *Reader) Int64(x *int64) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
@@ -73,7 +72,7 @@ func (r *Reader) Int64(x *int64) {
 
 // Float32 reads a little endian float32 from the underlying buffer.
 func (r *Reader) Float32(x *float32) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
@@ -82,7 +81,7 @@ func (r *Reader) Float32(x *float32) {
 
 // Float64 reads a little endian float64 from the underlying buffer.
 func (r *Reader) Float64(x *float64) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}

--- a/minecraft/protocol/reader_little_endian.go
+++ b/minecraft/protocol/reader_little_endian.go
@@ -4,48 +4,48 @@ package protocol
 
 import (
 	"encoding/binary"
-	"unsafe"
+	"math"
 )
 
 // Uint16 reads a little endian uint16 from the underlying buffer.
 func (r *Reader) Uint16(x *uint16) {
-	b := make([]byte, 2)
+	b := r.buf[:2]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
-	*x = *(*uint16)(unsafe.Pointer(&b[0]))
+	*x = binary.LittleEndian.Uint16(b)
 }
 
 // Int16 reads a little endian int16 from the underlying buffer.
 func (r *Reader) Int16(x *int16) {
-	b := make([]byte, 2)
+	b := r.buf[:2]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
-	*x = *(*int16)(unsafe.Pointer(&b[0]))
+	*x = int16(binary.LittleEndian.Uint16(b))
 }
 
 // Uint32 reads a little endian uint32 from the underlying buffer.
 func (r *Reader) Uint32(x *uint32) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
-	*x = *(*uint32)(unsafe.Pointer(&b[0]))
+	*x = binary.LittleEndian.Uint32(b)
 }
 
 // Int32 reads a little endian int32 from the underlying buffer.
 func (r *Reader) Int32(x *int32) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
-	*x = *(*int32)(unsafe.Pointer(&b[0]))
+	*x = int32(binary.LittleEndian.Uint32(b))
 }
 
 // BEInt32 reads a big endian int32 from the underlying buffer.
 func (r *Reader) BEInt32(x *int32) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
@@ -54,36 +54,36 @@ func (r *Reader) BEInt32(x *int32) {
 
 // Uint64 reads a little endian uint64 from the underlying buffer.
 func (r *Reader) Uint64(x *uint64) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
-	*x = *(*uint64)(unsafe.Pointer(&b[0]))
+	*x = binary.LittleEndian.Uint64(b)
 }
 
 // Int64 reads a little endian int64 from the underlying buffer.
 func (r *Reader) Int64(x *int64) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
-	*x = *(*int64)(unsafe.Pointer(&b[0]))
+	*x = int64(binary.LittleEndian.Uint64(b))
 }
 
 // Float32 reads a little endian float32 from the underlying buffer.
 func (r *Reader) Float32(x *float32) {
-	b := make([]byte, 4)
+	b := r.buf[:4]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
-	*x = *(*float32)(unsafe.Pointer(&b[0]))
+	*x = math.Float32frombits(binary.LittleEndian.Uint32(b))
 }
 
 // Float64 reads a little endian float64 from the underlying buffer.
 func (r *Reader) Float64(x *float64) {
-	b := make([]byte, 8)
+	b := r.buf[:8]
 	if _, err := r.r.Read(b); err != nil {
 		r.panic(err)
 	}
-	*x = *(*float64)(unsafe.Pointer(&b[0]))
+	*x = math.Float64frombits(binary.LittleEndian.Uint64(b))
 }

--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -26,6 +26,7 @@ type Writer struct {
 		io.ByteWriter
 	}
 	shieldID int32
+	buf      [8]byte
 }
 
 // NewWriter creates a new initialised Writer with an underlying io.ByteWriter to write to.

--- a/minecraft/protocol/writer_big_endian.go
+++ b/minecraft/protocol/writer_big_endian.go
@@ -5,67 +5,67 @@ package protocol
 import (
 	"encoding/binary"
 	"math"
-	"unsafe"
 )
 
 // Uint16 writes a little endian uint16 to the underlying buffer.
 func (w *Writer) Uint16(x *uint16) {
-	data := make([]byte, 2)
+	data := w.buf[:2]
 	binary.LittleEndian.PutUint16(data, *x)
 	_, _ = w.w.Write(data)
 }
 
 // Int16 writes a little endian int16 to the underlying buffer.
 func (w *Writer) Int16(x *int16) {
-	data := make([]byte, 2)
+	data := w.buf[:2]
 	binary.LittleEndian.PutUint16(data, uint16(*x))
 	_, _ = w.w.Write(data)
 }
 
 // Uint32 writes a little endian uint32 to the underlying buffer.
 func (w *Writer) Uint32(x *uint32) {
-	data := make([]byte, 4)
+	data := w.buf[:4]
 	binary.LittleEndian.PutUint32(data, *x)
 	_, _ = w.w.Write(data)
 }
 
 // Int32 writes a little endian int32 to the underlying buffer.
 func (w *Writer) Int32(x *int32) {
-	data := make([]byte, 4)
+	data := w.buf[:4]
 	binary.LittleEndian.PutUint32(data, uint32(*x))
 	_, _ = w.w.Write(data)
 }
 
 // BEInt32 writes a big endian int32 to the underlying buffer.
 func (w *Writer) BEInt32(x *int32) {
-	data := *(*[4]byte)(unsafe.Pointer(x))
-	_, _ = w.w.Write(data[:])
+	data := w.buf[:4]
+	binary.BigEndian.PutUint32(data, uint32(*x))
+	_, _ = w.w.Write(data)
 }
 
 // Uint64 writes a little endian uint64 to the underlying buffer.
 func (w *Writer) Uint64(x *uint64) {
-	data := make([]byte, 8)
+	data := w.buf[:8]
 	binary.LittleEndian.PutUint64(data, *x)
 	_, _ = w.w.Write(data)
 }
 
 // Int64 writes a little endian int64 to the underlying buffer.
 func (w *Writer) Int64(x *int64) {
-	data := make([]byte, 8)
+	data := w.buf[:8]
 	binary.LittleEndian.PutUint64(data, uint64(*x))
 	_, _ = w.w.Write(data)
 }
 
 // Float32 writes a little endian float32 to the underlying buffer.
 func (w *Writer) Float32(x *float32) {
-	data := make([]byte, 4)
+	data := w.buf[:4]
 	binary.LittleEndian.PutUint32(data, math.Float32bits(*x))
 	_, _ = w.w.Write(data)
 }
 
 // Float64 writes a little endian float64 to the underlying buffer.
 func (w *Writer) Float64(x *float64) {
-	data := make([]byte, 8)
+	data := w.buf[:8]
 	binary.LittleEndian.PutUint64(data, math.Float64bits(*x))
 	_, _ = w.w.Write(data)
 }

--- a/minecraft/protocol/writer_little_endian.go
+++ b/minecraft/protocol/writer_little_endian.go
@@ -4,60 +4,68 @@ package protocol
 
 import (
 	"encoding/binary"
-	"unsafe"
+	"math"
 )
 
 // Uint16 writes a little endian uint16 to the underlying buffer.
 func (w *Writer) Uint16(x *uint16) {
-	data := *(*[2]byte)(unsafe.Pointer(x))
-	_, _ = w.w.Write(data[:])
+	data := w.buf[:2]
+	binary.LittleEndian.PutUint16(data, *x)
+	_, _ = w.w.Write(data)
 }
 
 // Int16 writes a little endian int16 to the underlying buffer.
 func (w *Writer) Int16(x *int16) {
-	data := *(*[2]byte)(unsafe.Pointer(x))
-	_, _ = w.w.Write(data[:])
+	data := w.buf[:2]
+	binary.LittleEndian.PutUint16(data, uint16(*x))
+	_, _ = w.w.Write(data)
 }
 
 // Uint32 writes a little endian uint32 to the underlying buffer.
 func (w *Writer) Uint32(x *uint32) {
-	data := *(*[4]byte)(unsafe.Pointer(x))
-	_, _ = w.w.Write(data[:])
+	data := w.buf[:4]
+	binary.LittleEndian.PutUint32(data, *x)
+	_, _ = w.w.Write(data)
 }
 
 // Int32 writes a little endian int32 to the underlying buffer.
 func (w *Writer) Int32(x *int32) {
-	data := *(*[4]byte)(unsafe.Pointer(x))
-	_, _ = w.w.Write(data[:])
+	data := w.buf[:4]
+	binary.LittleEndian.PutUint32(data, uint32(*x))
+	_, _ = w.w.Write(data)
 }
 
 // BEInt32 writes a big endian int32 to the underlying buffer.
 func (w *Writer) BEInt32(x *int32) {
-	data := make([]byte, 4)
+	data := w.buf[:4]
 	binary.BigEndian.PutUint32(data, uint32(*x))
 	_, _ = w.w.Write(data)
 }
 
 // Uint64 writes a little endian uint64 to the underlying buffer.
 func (w *Writer) Uint64(x *uint64) {
-	data := *(*[8]byte)(unsafe.Pointer(x))
-	_, _ = w.w.Write(data[:])
+	data := w.buf[:8]
+	binary.LittleEndian.PutUint64(data, *x)
+	_, _ = w.w.Write(data)
 }
 
 // Int64 writes a little endian int64 to the underlying buffer.
 func (w *Writer) Int64(x *int64) {
-	data := *(*[8]byte)(unsafe.Pointer(x))
-	_, _ = w.w.Write(data[:])
+	data := w.buf[:8]
+	binary.LittleEndian.PutUint64(data, uint64(*x))
+	_, _ = w.w.Write(data)
 }
 
 // Float32 writes a little endian float32 to the underlying buffer.
 func (w *Writer) Float32(x *float32) {
-	data := *(*[4]byte)(unsafe.Pointer(x))
-	_, _ = w.w.Write(data[:])
+	data := w.buf[:4]
+	binary.LittleEndian.PutUint32(data, math.Float32bits(*x))
+	_, _ = w.w.Write(data)
 }
 
 // Float64 writes a little endian float64 to the underlying buffer.
 func (w *Writer) Float64(x *float64) {
-	data := *(*[8]byte)(unsafe.Pointer(x))
-	_, _ = w.w.Write(data[:])
+	data := w.buf[:8]
+	binary.LittleEndian.PutUint64(data, math.Float64bits(*x))
+	_, _ = w.w.Write(data)
 }


### PR DESCRIPTION
## Summary

This removes per-call heap allocations from fixed-width scalar reads and writes in the protocol and NBT encoders/decoders.

Instead of allocating fresh 2/4/8 byte slices for each scalar operation, `Reader`, `Writer`, `offsetReader`, and `offsetWriter` now reuse small 8-byte scratch buffers. Variable-length strings and slices are unchanged.

## Performance

Median results:

  | Benchmark | Before | After | Delta |
  | --- | ---: | ---: | ---: |
  | protocol read scalars | 488.0 ns/op, 48 B/op, 9 allocs/op | 123.6 ns/op, 0 B/op, 0 allocs/op | -74.7% |
  | protocol write scalars | 440.7 ns/op, 48 B/op, 9 allocs/op | 117.8 ns/op, 0 B/op, 0 allocs/op | -73.3% |
  | NBT little-endian read scalars | 337.1 ns/op, 32 B/op, 5 allocs/op | 132.1 ns/op, 0 B/op, 0 allocs/op | -60.8% |
  | NBT little-endian write scalars | 281.5 ns/op, 32 B/op, 5 allocs/op | 89.6 ns/op, 0 B/op, 0 allocs/op | -68.2% |
  | NBT big-endian read scalars | 329.3 ns/op, 32 B/op, 5 allocs/op | 126.3 ns/op, 0 B/op, 0 allocs/op | -61.6% |
  | NBT big-endian write scalars | 282.6 ns/op, 32 B/op, 5 allocs/op | 88.5 ns/op, 0 B/op, 0 allocs/op | -68.7% 

Long-term results will be lower allocations -> less GC pressure & less CPU allocation on decoding