### PR TITLE
Make snappy 3-10x faster and 0 allocations, 28x faster than flate

### DIFF
--- a/minecraft/protocol/packet/compression.go
+++ b/minecraft/protocol/packet/compression.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"slices"
 	"sync"
 
 	"github.com/klauspost/compress/flate"
-	"github.com/klauspost/compress/snappy"
+	"github.com/klauspost/compress/s2"
 	"github.com/sandertv/gophertunnel/minecraft/internal"
 )
 
@@ -20,6 +21,10 @@ type Compression interface {
 	Compress(decompressed []byte) ([]byte, error)
 	// Decompress decompresses the given data and returns the decompressed data.
 	Decompress(compressed []byte, limit int) ([]byte, error)
+}
+
+type appendCompression interface {
+	CompressAppend(dst, decompressed []byte) ([]byte, error)
 }
 
 var (
@@ -157,11 +162,23 @@ func (snappyCompression) EncodeCompression() uint16 {
 
 // Compress ...
 func (snappyCompression) Compress(decompressed []byte) ([]byte, error) {
-	// Because Snappy allocates a slice only once, it is less important to have
-	// a dst slice pre-allocated. With flateCompression this is more important,
-	// because flate does a lot of smaller allocations which causes a
-	// considerable slowdown.
-	return snappy.Encode(nil, decompressed), nil
+	// Use the fast Snappy-compatible S2 encoder. The snappy.Encode wrapper uses
+	// EncodeSnappyBetter, which trades more CPU and retained scratch memory for a
+	// smaller output size.
+	return s2.EncodeSnappy(nil, decompressed), nil
+}
+
+func (snappyCompression) CompressAppend(dst, decompressed []byte) ([]byte, error) {
+	// Append into the caller-provided output buffer so Encoder can keep the
+	// batch header and compression ID in the same allocation as the payload.
+	n := s2.MaxEncodedLen(len(decompressed))
+	if n < 0 {
+		panic(s2.ErrTooLarge)
+	}
+	offset := len(dst)
+	dst = slices.Grow(dst, n)
+	encoded := s2.EncodeSnappy(dst[offset:offset:cap(dst)], decompressed)
+	return dst[:offset+len(encoded)], nil
 }
 
 // Decompress ...
@@ -169,14 +186,14 @@ func (snappyCompression) Decompress(compressed []byte, limit int) ([]byte, error
 	// Snappy writes a decoded data length prefix, so it can allocate the
 	// perfect size right away and only needs to allocate once. No need to pool
 	// byte slices here either.
-	decodedLen, err := snappy.DecodedLen(compressed)
+	decodedLen, err := s2.DecodedLen(compressed)
 	if err != nil {
 		return nil, fmt.Errorf("snappy decoded length: %w", err)
 	}
 	if decodedLen > limit {
 		return nil, fmt.Errorf("snappy decoded size %d exceeds limit %d", decodedLen, limit)
 	}
-	decompressed, err := snappy.Decode(nil, compressed)
+	decompressed, err := s2.Decode(nil, compressed)
 	if err != nil {
 		return nil, fmt.Errorf("decompress snappy: %w", err)
 	}

--- a/minecraft/protocol/packet/compression.go
+++ b/minecraft/protocol/packet/compression.go
@@ -25,6 +25,7 @@ type Compression interface {
 
 type appendCompression interface {
 	CompressAppend(dst, decompressed []byte) ([]byte, error)
+	MaxCompressedLen(decompressedLen int) int
 }
 
 var (
@@ -179,6 +180,10 @@ func (snappyCompression) CompressAppend(dst, decompressed []byte) ([]byte, error
 	dst = slices.Grow(dst, n)
 	encoded := s2.EncodeSnappy(dst[offset:offset:cap(dst)], decompressed)
 	return dst[:offset+len(encoded)], nil
+}
+
+func (snappyCompression) MaxCompressedLen(decompressedLen int) int {
+	return s2.MaxEncodedLen(decompressedLen)
 }
 
 // Decompress ...

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -125,7 +125,6 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 		if len(batch) < encoder.compressionThreshold {
 			data[len(encoder.header)] = byte(NopCompression.EncodeCompression())
 		} else {
-			data[len(encoder.header)] = byte(compression.EncodeCompression())
 			compressedBuf = internal.BufferPool.Get().(*bytes.Buffer)
 			_, _ = compressedBuf.Write(encoder.header)
 			_ = compressedBuf.WriteByte(byte(compression.EncodeCompression()))

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/sandertv/gophertunnel/minecraft/internal"
 )
@@ -87,16 +88,28 @@ func (encoder *Encoder) EnableCompression(compression Compression, threshold int
 // optionally encrypted.
 func (encoder *Encoder) Encode(packets [][]byte) error {
 	buf := internal.BufferPool.Get().(*bytes.Buffer)
+	var compressedBuf *bytes.Buffer
 	defer func() {
 		// Reset the buffer, so we can return it to the buffer pool safely.
 		buf.Reset()
 		internal.BufferPool.Put(buf)
+		if compressedBuf != nil {
+			compressedBuf.Reset()
+			internal.BufferPool.Put(compressedBuf)
+		}
 	}()
 
-	l := make([]byte, 5)
+	compression := encoder.compression
+	_, _ = buf.Write(encoder.header)
+	if compression != nil {
+		_ = buf.WriteByte(0)
+	}
+	batchStart := buf.Len()
+
+	var l [5]byte
 	for _, packet := range packets {
 		// Each packet is prefixed with a varuint32 specifying the length of the packet.
-		if err := writeVaruint32(buf, uint32(len(packet)), l); err != nil {
+		if _, err := buf.Write(l[:putVaruint32(&l, uint32(len(packet)))]); err != nil {
 			return fmt.Errorf("encode batch: write packet length: %w", err)
 		}
 		if _, err := buf.Write(packet); err != nil {
@@ -105,24 +118,30 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 	}
 
 	data := buf.Bytes()
-	prepend := encoder.header
+	if compression != nil {
+		batch := data[batchStart:]
+		if len(batch) < encoder.compressionThreshold {
+			data[len(encoder.header)] = byte(NopCompression.EncodeCompression())
+		} else {
+			compressed, err := compression.Compress(batch)
+			if err != nil {
+				return fmt.Errorf("compress batch: %w", err)
+			}
 
-	if compression := encoder.compression; compression != nil {
-		if len(data) < encoder.compressionThreshold {
-			compression = NopCompression
+			compressedBuf = internal.BufferPool.Get().(*bytes.Buffer)
+			_, _ = compressedBuf.Write(encoder.header)
+			_ = compressedBuf.WriteByte(byte(compression.EncodeCompression()))
+			if _, err := compressedBuf.Write(compressed); err != nil {
+				return fmt.Errorf("compress batch: write compressed payload: %w", err)
+			}
+			data = compressedBuf.Bytes()
 		}
-		var err error
-		data, err = compression.Compress(data)
-		if err != nil {
-			return fmt.Errorf("compress batch: %w", err)
-		}
-		prepend = append(prepend, byte(compression.EncodeCompression()))
 	}
 
-	data = append(prepend, data...)
 	if encoder.encrypt != nil {
 		// If the encryption session is not nil, encryption is enabled, meaning we should encrypt the
 		// compressed data of this packet.
+		data = slices.Grow(data, 8)
 		data = encoder.encrypt.encrypt(data)
 	}
 	if _, err := encoder.w.Write(data); err != nil {
@@ -131,10 +150,9 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 	return nil
 }
 
-// writeVaruint32 writes a uint32 to the destination buffer passed with a size of 1-5 bytes. It uses byte
-// slice b in order to prevent allocations.
-func writeVaruint32(dst io.Writer, x uint32, b []byte) error {
-	clear(b[:5])
+// putVaruint32 writes x to b with a size of 1-5 bytes and returns the number of
+// bytes written.
+func putVaruint32(b *[5]byte, x uint32) int {
 	i := 0
 	for x >= 0x80 {
 		b[i] = byte(x) | 0x80
@@ -142,6 +160,5 @@ func writeVaruint32(dst io.Writer, x uint32, b []byte) error {
 		x >>= 7
 	}
 	b[i] = byte(x)
-	_, err := dst.Write(b[:i+1])
-	return err
+	return i + 1
 }

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/internal"
 )
 
+const maxPooledEncoderBufferCap = 1 << 20
+
 // Encoder handles the encoding of Minecraft packets that are sent to an io.Writer. The packets are compressed
 // and optionally encoded before they are sent to the io.Writer.
 type Encoder struct {
@@ -93,7 +95,7 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 		// Reset the buffer, so we can return it to the buffer pool safely.
 		buf.Reset()
 		internal.BufferPool.Put(buf)
-		if compressedBuf != nil {
+		if compressedBuf != nil && compressedBuf.Cap() <= maxPooledEncoderBufferCap {
 			compressedBuf.Reset()
 			internal.BufferPool.Put(compressedBuf)
 		}

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -127,11 +127,15 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 			compressedBuf = internal.BufferPool.Get().(*bytes.Buffer)
 			_, _ = compressedBuf.Write(encoder.header)
 			_ = compressedBuf.WriteByte(byte(compression.EncodeCompression()))
-			dst := compressedBuf.Bytes()
 			var err error
 			if appender, ok := compression.(appendCompression); ok {
+				if n := appender.MaxCompressedLen(len(batch)); n > 0 {
+					compressedBuf.Grow(n)
+				}
+				dst := compressedBuf.Bytes()
 				data, err = appender.CompressAppend(dst, batch)
 			} else {
+				dst := compressedBuf.Bytes()
 				var compressed []byte
 				compressed, err = compression.Compress(batch)
 				data = append(dst, compressed...)

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -123,18 +123,22 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 		if len(batch) < encoder.compressionThreshold {
 			data[len(encoder.header)] = byte(NopCompression.EncodeCompression())
 		} else {
-			compressed, err := compression.Compress(batch)
-			if err != nil {
-				return fmt.Errorf("compress batch: %w", err)
-			}
-
+			data[len(encoder.header)] = byte(compression.EncodeCompression())
 			compressedBuf = internal.BufferPool.Get().(*bytes.Buffer)
 			_, _ = compressedBuf.Write(encoder.header)
 			_ = compressedBuf.WriteByte(byte(compression.EncodeCompression()))
-			if _, err := compressedBuf.Write(compressed); err != nil {
-				return fmt.Errorf("compress batch: write compressed payload: %w", err)
+			dst := compressedBuf.Bytes()
+			var err error
+			if appender, ok := compression.(appendCompression); ok {
+				data, err = appender.CompressAppend(dst, batch)
+			} else {
+				var compressed []byte
+				compressed, err = compression.Compress(batch)
+				data = append(dst, compressed...)
 			}
-			data = compressedBuf.Bytes()
+			if err != nil {
+				return fmt.Errorf("compress batch: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
- Switches Snappy compression from `snappy.Encode` to `s2.EncodeSnappy`, keeping Snappy-compatible output while making the hot encode path much faster.
- Adds an append-based Snappy path so compressed data is written into the encoder output buffer directly, avoiding the extra compressed slice/copy.
- Eliminates Snappy encode allocations for compressed batches that stay within the `1 MiB` pooled encoder buffer cap.

In benchmarks, the new Snappy path reaches ~5.98-35.89 Gbps effective encode throughput, is 2.5x-9.6x faster than the previous Snappy path, and up to ~28x faster than Flate depending on batch size

<img width="1342" height="150" alt="image" src="https://github.com/user-attachments/assets/5d44d15a-3837-471a-ba08-325d98051e8e" />


Benchmark code
```go
package packet

import (
      "io"
      "testing"
)

func BenchmarkEncoderCompression(b *testing.B) {
      cases := []struct {
              name       string
              packets    int
              packetSize int
      }{
              {name: "1x1KiB", packets: 1, packetSize: 1 << 10},
              {name: "16x1KiB", packets: 16, packetSize: 1 << 10},
              {name: "1x128KiB", packets: 1, packetSize: 128 << 10},
              {name: "4x128KiB", packets: 4, packetSize: 128 << 10},
              {name: "8x128KiB", packets: 8, packetSize: 128 << 10},
      }

      compressions := []struct {
              name        string
              compression Compression
      }{
              {name: "Snappy", compression: SnappyCompression},
              {name: "Flate", compression: FlateCompression},
      }

      for _, c := range cases {
              packets, total := benchmarkPackets(c.packets, c.packetSize)

              for _, compression := range compressions {
                      b.Run(c.name+"/"+compression.name, func(b *testing.B) {
                              encoder := NewEncoder(io.Discard)
                              encoder.EnableCompression(compression.compression, 0)

                              b.ReportAllocs()
                              b.SetBytes(int64(total))
                              b.ResetTimer()

                              for i := 0; i < b.N; i++ {
                                      if err := encoder.Encode(packets); err != nil {
                                              b.Fatal(err)
                                      }
                              }
                      })
              }
      }
}

func benchmarkPackets(n, size int) ([][]byte, int) {
      packets := make([][]byte, n)
      total := 0

      for i := range packets {
              p := make([]byte, size)
              for j := range p {
                      p[j] = byte((j*31 + i*17) & 0xff)
              }
              packets[i] = p
              total += len(p)
      }

      return packets, total
}
```