### PR TITLE
Fix ServerBoundDataDrivenScreenClosedPacket Marshal

### DIFF
--- a/minecraft/protocol/packet/serverbound_data_driven_screen_closed.go
+++ b/minecraft/protocol/packet/serverbound_data_driven_screen_closed.go
@@ -5,11 +5,11 @@ import (
 )
 
 const (
-	DataDrivenScreenCloseReasonProgrammaticClose = iota
-	DataDrivenScreenCloseReasonProgrammaticCloseAll
-	DataDrivenScreenCloseReasonClientCanceled
-	DataDrivenScreenCloseReasonUserBusy
-	DataDrivenScreenCloseReasonInvalidForm
+	DataDrivenScreenCloseReasonProgrammaticClose    = "programmaticclose"
+	DataDrivenScreenCloseReasonProgrammaticCloseAll = "programmaticcloseall"
+	DataDrivenScreenCloseReasonClientCanceled       = "clientcanceled"
+	DataDrivenScreenCloseReasonUserBusy             = "userbusy"
+	DataDrivenScreenCloseReasonInvalidForm          = "invalidform"
 )
 
 // ServerBoundDataDrivenScreenClosed is sent by the client when a data-driven UI screen is closed.
@@ -17,7 +17,7 @@ type ServerBoundDataDrivenScreenClosed struct {
 	// FormID is the optional unique instance ID of the form that was closed.
 	FormID protocol.Optional[uint32]
 	// CloseReason is the reason the screen was closed. It is one of the DataDrivenScreenCloseReason constants.
-	CloseReason uint8
+	CloseReason string
 }
 
 // ID ...
@@ -27,5 +27,5 @@ func (*ServerBoundDataDrivenScreenClosed) ID() uint32 {
 
 func (pk *ServerBoundDataDrivenScreenClosed) Marshal(io protocol.IO) {
 	protocol.OptionalFunc(io, &pk.FormID, io.Uint32)
-	io.Uint8(&pk.CloseReason)
+	io.String(&pk.CloseReason)
 }


### PR DESCRIPTION
Source:

https://github.com/Mojang/bedrock-protocol-docs/blob/b88f3eed28d59b86e7ad00dba4f0e8640d2e90b8/json/ServerboundDataDrivenScreenClosedPacket.json#L11-L24

https://github.com/CloudburstMC/Protocol/blob/3.0/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v944/serializer/ServerboundDataDrivenScreenClosedSerializer_v944.java#L24

Got this while testing DDUI and saw that docs... they wrote the docs wrongly :(
```
2026/06/10 14:39:56 ERROR read packet: decode packet *packet.ServerBoundDataDrivenScreenClosed: 13 unread bytes left: 0x6c69656e7463616e63656c6564 "net origin"=gophertunnel src=listener raddr=127.0.0.1:59187
```
