### PR TITLE
Fixed PlayerInventoryAction using the incorrect ItemInstance marshal

### DIFF
--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -274,7 +274,7 @@ func (r *Reader) PlayerInventoryAction(x *UseItemTransactionData) {
 	r.BlockPos(&x.BlockPosition)
 	r.Varint32(&x.BlockFace)
 	r.Varint32(&x.HotBarSlot)
-	r.ItemInstanceNew(&x.HeldItem)
+	r.ItemInstance(&x.HeldItem)
 	r.Vec3(&x.Position)
 	r.Vec3(&x.ClickedPosition)
 	r.Varuint32(&x.BlockRuntimeID)

--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -202,7 +202,7 @@ func (w *Writer) PlayerInventoryAction(x *UseItemTransactionData) {
 	w.BlockPos(&x.BlockPosition)
 	w.Varint32(&x.BlockFace)
 	w.Varint32(&x.HotBarSlot)
-	w.ItemInstanceNew(&x.HeldItem)
+	w.ItemInstance(&x.HeldItem)
 	w.Vec3(&x.Position)
 	w.Vec3(&x.ClickedPosition)
 	w.Varuint32(&x.BlockRuntimeID)


### PR DESCRIPTION
```
read packet: decode packet *packet.PlayerAuthInput: byte slice length 10942 exceeds remaining packet payload 54
```