### PR TITLE
Fixed packet.PlayerAuthInput marshal errors due to using new InventoryAction

### DIFF
--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -268,7 +268,7 @@ func (r *Reader) PlayerInventoryAction(x *UseItemTransactionData) {
 	if x.LegacyRequestID < -1 && (x.LegacyRequestID&1) == 0 {
 		Slice(r, &x.LegacySetItemSlots)
 	}
-	Slice(r, &x.Actions)
+	FuncSlice(r, &x.Actions, r.inventoryActionOld)
 	r.Varuint32(&x.ActionType)
 	r.Varuint32(&x.TriggerType)
 	r.BlockPos(&x.BlockPosition)
@@ -280,6 +280,21 @@ func (r *Reader) PlayerInventoryAction(x *UseItemTransactionData) {
 	r.Varuint32(&x.BlockRuntimeID)
 	r.Uint8(&x.ClientPrediction)
 	r.Uint8(&x.ClientCooldownState)
+}
+
+func (r *Reader) inventoryActionOld(x *InventoryAction) {
+	r.Varuint32(&x.SourceType)
+	switch x.SourceType {
+	case InventoryActionSourceContainer, InventoryActionSourceTODO:
+		var windowID int32
+		r.Varint32(&windowID)
+		x.WindowID = int8(windowID)
+	case InventoryActionSourceWorld:
+		r.Varuint32(&x.SourceFlags)
+	}
+	r.Varuint32(&x.InventorySlot)
+	r.ItemInstance(&x.OldItem)
+	r.ItemInstance(&x.NewItem)
 }
 
 // GameRule reads a GameRule x from the Reader.

--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -196,7 +196,7 @@ func (w *Writer) PlayerInventoryAction(x *UseItemTransactionData) {
 	if x.LegacyRequestID < -1 && (x.LegacyRequestID&1) == 0 {
 		Slice(w, &x.LegacySetItemSlots)
 	}
-	Slice(w, &x.Actions)
+	FuncSlice(w, &x.Actions, w.inventoryActionOld)
 	w.Varuint32(&x.ActionType)
 	w.Varuint32(&x.TriggerType)
 	w.BlockPos(&x.BlockPosition)
@@ -208,6 +208,20 @@ func (w *Writer) PlayerInventoryAction(x *UseItemTransactionData) {
 	w.Varuint32(&x.BlockRuntimeID)
 	w.Uint8(&x.ClientPrediction)
 	w.Uint8(&x.ClientCooldownState)
+}
+
+func (w *Writer) inventoryActionOld(x *InventoryAction) {
+	w.Varuint32(&x.SourceType)
+	switch x.SourceType {
+	case InventoryActionSourceContainer, InventoryActionSourceTODO:
+		windowID := int32(x.WindowID)
+		w.Varint32(&windowID)
+	case InventoryActionSourceWorld:
+		w.Varuint32(&x.SourceFlags)
+	}
+	w.Varuint32(&x.InventorySlot)
+	w.ItemInstance(&x.OldItem)
+	w.ItemInstance(&x.NewItem)
 }
 
 // GameRule writes a GameRule x to the Writer.


### PR DESCRIPTION
Error:
```
read packet: decode packet *packet.PlayerAuthInput: nbt: unexpected buffer end during op: 'String'
```