### PR TITLE
Name packet transport capability contracts

### DIFF
--- a/minecraft/network.go
+++ b/minecraft/network.go
@@ -12,6 +12,9 @@ type Network interface {
 	// hostname, combined with a port that is separated with ':'.
 	// DialContext will use the deadline (ctx.Deadline) of the context.Context passed for the maximum amount of time that
 	// the dialing can take. DialContext will terminate as soon as possible when the context.Context is closed.
+	//
+	// If the returned connection implements optional packet transport capabilities from the packet package, wrappers around
+	// the connection must preserve those methods. Hiding them can change packet framing, encryption or read behaviour.
 	DialContext(ctx context.Context, address string) (net.Conn, error)
 	// PingContext sends a ping to an address and returns the response obtained. If successful, a non-nil response byte
 	// slice containing the data is returned. If the ping failed, an error is returned describing the failure.

--- a/minecraft/protocol/packet/decoder.go
+++ b/minecraft/protocol/packet/decoder.go
@@ -18,9 +18,9 @@ type Decoder struct {
 	r   io.Reader
 	buf []byte
 
-	// pr holds a packetReader (and io.Reader) that packets are read from if the io.Reader passed to
-	// NewDecoder implements the packetReader interface.
-	pr packetReader
+	// pr holds a PacketReader (and io.Reader) that packets are read from if the io.Reader passed to
+	// NewDecoder implements the PacketReader interface.
+	pr PacketReader
 
 	// header holds the batch header that is expected on the beginning of input packet data.
 	header []byte
@@ -36,26 +36,20 @@ type Decoder struct {
 	checkPacketLimit bool
 }
 
-// packetReader is used to read packets immediately instead of copying them in a buffer first. This is a
-// specific case made to reduce RAM usage.
-type packetReader interface {
-	ReadPacket() ([]byte, error)
-}
-
 // NewDecoder returns a new decoder decoding data from the io.Reader passed. One read call from the reader is
 // assumed to consume an entire packet.
 func NewDecoder(reader io.Reader) *Decoder {
 	var batch []byte
-	if b, ok := reader.(batchHeader); ok {
+	if b, ok := reader.(BatchHeaderer); ok {
 		batch = b.BatchHeader()
 	} else {
 		batch = []byte{header}
 	}
 	var disableEncryption bool
-	if d, ok := reader.(encryptionDisabler); ok {
+	if d, ok := reader.(EncryptionDisabler); ok {
 		disableEncryption = d.DisableEncryption()
 	}
-	if pr, ok := reader.(packetReader); ok {
+	if pr, ok := reader.(PacketReader); ok {
 		return &Decoder{
 			checkPacketLimit:  true,
 			pr:                pr,

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -33,13 +33,13 @@ type Encoder struct {
 // sent with a single call to io.Writer.Write().
 func NewEncoder(w io.Writer) *Encoder {
 	var batch []byte
-	if b, ok := w.(batchHeader); ok {
+	if b, ok := w.(BatchHeaderer); ok {
 		batch = b.BatchHeader()
 	} else {
 		batch = []byte{header}
 	}
 	var disableEncryption bool
-	if d, ok := w.(encryptionDisabler); ok {
+	if d, ok := w.(EncryptionDisabler); ok {
 		disableEncryption = d.DisableEncryption()
 	}
 	return &Encoder{
@@ -47,25 +47,6 @@ func NewEncoder(w io.Writer) *Encoder {
 		header:            batch,
 		disableEncryption: disableEncryption,
 	}
-}
-
-// batchHeader can be implemented by underlying transport connection provided to Encoder and Decoder
-// to specify the initial bytes that should appear at the beginning of packet data in wire.
-type batchHeader interface {
-	// BatchHeader returns initial bytes that should be appended to the produced data
-	// in Encoder and Decoder. It can be an empty slice if nothing is expected at the beginning.
-	BatchHeader() []byte
-}
-
-// encryptionDisabler may be implemented by the underlying transport connection to
-// prevent encryption from being enabled in Encoder and Decoder.
-//
-// Disabling encryption is strongly discouraged, as it removes protection against
-// replay attacks during login. Use only if you fully understand the implications.
-type encryptionDisabler interface {
-	// DisableEncryption reports whether encryption should be disabled for both
-	// Encoder and Decoder.
-	DisableEncryption() bool
 }
 
 // EnableEncryption enables encryption for the Encoder using the secret key bytes passed. Each packet sent

--- a/minecraft/protocol/packet/transport.go
+++ b/minecraft/protocol/packet/transport.go
@@ -25,12 +25,11 @@ type PacketReader interface {
 	ReadPacket() ([]byte, error)
 }
 
-// TransportCapabilities groups optional packet-layer methods that transport
-// wrappers must preserve.
+// TransportCapabilities is the full set of optional packet transport methods.
 //
-// Implementing this full interface is not required for ordinary transports, but
-// wrappers around a transport that does implement these methods must keep them
-// visible or packet framing and encryption behaviour may change.
+// Normal transports do not need to implement this interface. If code wraps a
+// connection that has any of these methods, the wrapper must expose the same
+// methods too. Otherwise packets may be framed, encrypted, or read differently.
 type TransportCapabilities interface {
 	BatchHeaderer
 	EncryptionDisabler

--- a/minecraft/protocol/packet/transport.go
+++ b/minecraft/protocol/packet/transport.go
@@ -1,0 +1,38 @@
+package packet
+
+// BatchHeaderer may be implemented by transports that need a custom batch prefix.
+//
+// The default Minecraft packet transport uses the standard batch header. Transports
+// such as NetherNet can return nil when packets are already framed by the transport.
+type BatchHeaderer interface {
+	// BatchHeader returns the bytes expected before each packet batch.
+	BatchHeader() []byte
+}
+
+// EncryptionDisabler may be implemented by transports that must not use
+// Minecraft packet encryption.
+//
+// This is intended for transports that already provide their own encryption.
+type EncryptionDisabler interface {
+	// DisableEncryption reports whether Minecraft packet encryption should be disabled.
+	DisableEncryption() bool
+}
+
+// PacketReader may be implemented by transports that can read complete packet
+// payloads directly.
+type PacketReader interface {
+	// ReadPacket reads one complete packet payload from the transport.
+	ReadPacket() ([]byte, error)
+}
+
+// TransportCapabilities groups optional packet-layer methods that transport
+// wrappers must preserve.
+//
+// Implementing this full interface is not required for ordinary transports, but
+// wrappers around a transport that does implement these methods must keep them
+// visible or packet framing and encryption behaviour may change.
+type TransportCapabilities interface {
+	BatchHeaderer
+	EncryptionDisabler
+	PacketReader
+}

--- a/minecraft/protocol/packet/transport.go
+++ b/minecraft/protocol/packet/transport.go
@@ -29,7 +29,7 @@ type PacketReader interface {
 //
 // Normal transports do not need to implement this interface. If code wraps a
 // connection that has any of these methods, the wrapper must expose the same
-// methods too. Otherwise packets may be framed, encrypted, or read differently.
+// methods too so Encoder and Decoder keep using the transport-specific behavior.
 type TransportCapabilities interface {
 	BatchHeaderer
 	EncryptionDisabler


### PR DESCRIPTION
This PR names and documents the optional packet transport capabilities already used by the encoder and decoder. This keeps the existing net.Conn-based API, but gives custom transports and wrappers a clear contract: if a connection exposes transport-specific packet behavior, wrappers must preserve those methods. NetherNet support can then assert that *nethernet.Conn satisfies the full capability set, preventing silent fallback to default packet framing/encryption behavior.
