### PR TITLE
Use versioned resource pack IDs for DataInfo

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -1231,7 +1231,8 @@ func (conn *Conn) handleResourcePackChunkData(pk *packet.ResourcePackChunkData) 
 // pack to be downloaded.
 func (conn *Conn) handleResourcePackChunkRequest(pk *packet.ResourcePackChunkRequest) error {
 	current := conn.packQueue.currentPack
-	if current.UUID().String() != pk.UUID {
+	uuid, _, _ := strings.Cut(pk.UUID, "_")
+	if current.UUID().String() != uuid {
 		return fmt.Errorf("expected pack UUID %v, but got %v", current.UUID(), pk.UUID)
 	}
 	if conn.packQueue.currentOffset != uint64(pk.ChunkIndex)*packChunkSize {

--- a/minecraft/resource_pack_queue.go
+++ b/minecraft/resource_pack_queue.go
@@ -3,6 +3,8 @@ package minecraft
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 	"github.com/sandertv/gophertunnel/minecraft/resource"
 )
@@ -30,24 +32,23 @@ type downloadingPack struct {
 	contentKey    string
 }
 
-// Request 'requests' all resource packs passed, provided they all exist in the resourcePackQueue. If not,
-// an error is returned.
+// Request 'requests' all resource packs passed, provided they all exist in the resourcePackQueue. Clients
+// generally request packs as "uuid_version", and ResourcePackDataInfo must use that same identifier shape so
+// the client can match the response to its request. Bare UUID requests are accepted for compatibility.
 func (queue *resourcePackQueue) Request(packs []string) error {
 	queue.packsToDownload = make(map[string]*resource.Pack)
-	for _, packUUID := range packs {
+	for _, requestedPackID := range packs {
+		uuid, version, hasVersion := strings.Cut(requestedPackID, "_")
 		found := false
 		for _, pack := range queue.packs {
-			// Mojang made some hack that merges the UUID with the version, so we need to combine that here
-			// too in order to find the proper pack.
-			id := pack.UUID().String()
-			if id+"_"+pack.Version() == packUUID {
-				queue.packsToDownload[id] = pack
+			if uuid == pack.UUID().String() && (!hasVersion || version == "" || version == pack.Version()) {
+				queue.packsToDownload[pack.UUID().String()] = pack
 				found = true
 				break
 			}
 		}
 		if !found {
-			return fmt.Errorf("resource pack (UUID=%v) not found", packUUID)
+			return fmt.Errorf("resource pack (UUID=%v) not found", requestedPackID)
 		}
 	}
 	return nil
@@ -77,7 +78,7 @@ func (queue *resourcePackQueue) NextPack() (pk *packet.ResourcePackDataInfo, ok 
 			packType = packet.ResourcePackTypeSkins
 		}
 		return &packet.ResourcePackDataInfo{
-			UUID:          pack.UUID().String(),
+			UUID:          pack.UUID().String() + "_" + pack.Version(),
 			DataChunkSize: packChunkSize,
 			ChunkCount:    uint32(pack.DataChunkCount(packChunkSize)),
 			Size:          uint64(pack.Len()),


### PR DESCRIPTION
## Summary

- send proxy-served `ResourcePackDataInfo.UUID` as `uuid_version`, matching the identifier clients request from `ResourcePacksInfo`
- keep request/chunk matching tolerant of bare UUIDs so existing flows still work

## Notes

BDS builds the resource pack data-info name from the pack ID plus version. Sending only the bare UUID can leave the client unable to associate the data-info packet with the pack it requested.

## Tests

- `go test ./minecraft ./minecraft/protocol/packet`
