### PR TITLE
minecraft/protocol: Add double and list data store property types

### DIFF
--- a/minecraft/protocol/data_store.go
+++ b/minecraft/protocol/data_store.go
@@ -16,7 +16,9 @@ const (
 	DataStorePropertyTypeNone   = 0
 	DataStorePropertyTypeBool   = 1
 	DataStorePropertyTypeInt64  = 2
+	DataStorePropertyTypeDouble = 3
 	DataStorePropertyTypeString = 4
+	DataStorePropertyTypeList   = 5
 	DataStorePropertyTypeMap    = 6
 )
 
@@ -100,8 +102,12 @@ type DataStorePropertyValue struct {
 	BoolValue bool
 	// Int64Value is the value if Type is DataStorePropertyTypeInt64.
 	Int64Value int64
+	// DoubleValue is the value if Type is DataStorePropertyTypeDouble.
+	DoubleValue float64
 	// StringValue is the value if Type is DataStorePropertyTypeString.
 	StringValue string
+	// ListValue is the value if Type is DataStorePropertyTypeList.
+	ListValue []DataStorePropertyValue
 	// MapValue is the value if Type is DataStorePropertyTypeMap.
 	MapValue []DataStoreMapEntry
 }
@@ -124,8 +130,14 @@ func MarshalDataStorePropertyValue(r IO, x *DataStorePropertyValue) {
 		r.Bool(&x.BoolValue)
 	case DataStorePropertyTypeInt64:
 		r.Int64(&x.Int64Value)
+	case DataStorePropertyTypeDouble:
+		r.Float64(&x.DoubleValue)
 	case DataStorePropertyTypeString:
 		r.String(&x.StringValue)
+	case DataStorePropertyTypeList:
+		FuncSlice(r, &x.ListValue, func(v *DataStorePropertyValue) {
+			MarshalDataStorePropertyValue(r, v)
+		})
 	case DataStorePropertyTypeMap:
 		FuncSlice(r, &x.MapValue, func(entry *DataStoreMapEntry) {
 			r.String(&entry.Key)


### PR DESCRIPTION
## Summary
- Add missing `DataStorePropertyTypeDouble` (3) and `DataStorePropertyTypeList` (5) to `MarshalDataStorePropertyValue`
- Matches `cereal::DynamicValue` / pmmp/BedrockProtocol `DynamicValueType` used by BDS 1.26.30+ data store change entries

Fixes proxy decode error:
`decode packet *packet.ClientBoundDataStore: unknown value '3' for enum type 'data store property type'`

## Test plan
- [x] `go build ./...`
- [ ] Proxy a BDS 1.26.30+ session that opens a custom form (data store `custom_form_data_*`) and confirm no ClientBoundDataStore decode errors
