### PR TITLE
Default listener logger before network lookup

### DIFF
--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -317,6 +317,10 @@ func (d Dialer) DialContextNetwork(ctx context.Context, network Network, address
 // typically "raknet". A Conn is returned which may be used to receive packets from and send packets to.
 // If a connection is not established before the context passed is cancelled, DialContext returns an error.
 func (d Dialer) DialContext(ctx context.Context, network, address string) (conn *Conn, err error) {
+	if d.ErrorLog == nil {
+		d.ErrorLog = slog.New(internal.DiscardHandler{})
+	}
+	d.ErrorLog = d.ErrorLog.With("src", "dialer")
 	n, ok := networkByID(network, d.ErrorLog)
 	if !ok {
 		return nil, &net.OpError{Op: "dial", Net: "minecraft", Err: fmt.Errorf("dial: no network under id %v", network)}

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -139,6 +139,9 @@ type Listener struct {
 // If the host in the address parameter is empty or a literal unspecified IP address, Listen listens on all
 // available unicast and anycast IP addresses of the local system.
 func (cfg ListenConfig) Listen(network string, address string) (*Listener, error) {
+	if cfg.ErrorLog == nil {
+		cfg.ErrorLog = slog.New(internal.DiscardHandler{})
+	}
 	n, ok := networkByID(network, cfg.ErrorLog)
 	if !ok {
 		return nil, fmt.Errorf("listen: no network under id %v", network)

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -142,6 +142,7 @@ func (cfg ListenConfig) Listen(network string, address string) (*Listener, error
 	if cfg.ErrorLog == nil {
 		cfg.ErrorLog = slog.New(internal.DiscardHandler{})
 	}
+	cfg.ErrorLog = cfg.ErrorLog.With("src", "listener")
 	n, ok := networkByID(network, cfg.ErrorLog)
 	if !ok {
 		return nil, fmt.Errorf("listen: no network under id %v", network)


### PR DESCRIPTION
default ListenConfig.ErrorLog before constructing the registered network

## Root cause
ListenConfig.Listen passed cfg.ErrorLog into networkByID before ListenNetwork applied the documented default logger. The registered RakNet network could therefore be constructed with a nil logger and panic when it called Logger.With.

Fixes #450.