### PR TITLE
[codex] Fix command argument type constants

### DIFF
--- a/minecraft/protocol/command.go
+++ b/minecraft/protocol/command.go
@@ -72,7 +72,9 @@ const (
 	CommandArgEnum     = 0x200000
 	CommandArgSuffixed = 0x1000000
 	CommandArgSoftEnum = 0x4000000
+)
 
+const (
 	CommandArgTypeInt = iota + 1
 	CommandArgTypeFloat
 	CommandArgTypeValue


### PR DESCRIPTION
## Summary
- Split command argument flags from the `iota`-based argument type constants.
- Restores the wire values so `CommandArgTypeInt` starts at `1` instead of being offset by the preceding flag constants.

## Root cause
`iota` was introduced in the same const block as the command argument flag values. That made every command argument type value four higher than the Bedrock parse-symbol value advertised in `AvailableCommands`.