### PR TITLE
protocol/packet: correct MobEffect.Duration doc (ticks, not seconds)

### DIFF
--- a/minecraft/protocol/packet/mob_effect.go
+++ b/minecraft/protocol/packet/mob_effect.go
@@ -59,8 +59,8 @@ type MobEffect struct {
 	// Particles specifies if viewers of the entity that gets the effect shows particles around it. If set to
 	// false, no particles are emitted around the entity.
 	Particles bool
-	// Duration is the duration of the effect in seconds. After the duration has elapsed, the effect will be
-	// removed automatically client-side.
+	// Duration is the duration of the effect in ticks (20 per second). After the duration has elapsed, the
+	// effect will be removed automatically client-side. A negative duration means the effect never expires.
 	Duration int32
 	// Tick is the server tick at which the packet was sent. It is used in relation to CorrectPlayerMovePrediction.
 	Tick uint64


### PR DESCRIPTION
`MobEffect.Duration` is documented as seconds, but the field carries Bedrock ticks:

- dragonfly encodes it as `dur := e.Duration() / (time.Second / 20)` before writing the packet (`server/session/player.go`, `SendEffect`), i.e. 20 units per second.
- Vanilla sends `-1` for the 1.19.30+ infinite effects, which the current comment doesn't cover.

This bit us in a proxy that timed out server-sent effects based on the doc comment — effects were considered active 20× too long, and infinite effects expired instantly. Doc-only change.