### PR TITLE
Update client_bound_debug_renderer.go

### DIFF
--- a/minecraft/protocol/packet/client_bound_debug_renderer.go
+++ b/minecraft/protocol/packet/client_bound_debug_renderer.go
@@ -1,6 +1,8 @@
 package packet
 
 import (
+	"image/color"
+
 	"github.com/go-gl/mathgl/mgl32"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 )
@@ -14,20 +16,31 @@ const (
 type ClientBoundDebugRenderer struct {
 	// Type is the type of action. It is one of the constants above.
 	Type uint32
+	// Data holds the marker data. It is only present when Type is
+	// ClientBoundDebugRendererAddCube.
+	Data protocol.Optional[DebugMarkerData]
+}
+
+// DebugMarkerData holds the data of a debug marker cube spawned through a
+// ClientBoundDebugRenderer packet.
+type DebugMarkerData struct {
 	// Text is the text that is displayed above the debug.
 	Text string
 	// Position is the position to spawn the debug on.
 	Position mgl32.Vec3
-	// Red is the red value from the RGBA colour rendered on the debug. This value is in the range 0-1.
-	Red float32
-	// Green is the green value from the RGBA colour rendered on the debug. This value is in the range 0-1.
-	Green float32
-	// Blue is the blue value from the RGBA colour rendered on the debug. This value is in the range 0-1.
-	Blue float32
-	// Alpha is the alpha value from the RGBA colour rendered on the debug. This value is in the range 0-1.
-	Alpha float32
+	// Colour is the RGBA colour rendered on the debug, packed as an ARGB uint32
+	// on the wire.
+	Colour color.RGBA
 	// Duration is how long the debug will last in the world for. It is measured in milliseconds.
 	Duration uint64
+}
+
+// Marshal ...
+func (x *DebugMarkerData) Marshal(io protocol.IO) {
+	io.String(&x.Text)
+	io.Vec3(&x.Position)
+	io.ARGB(&x.Colour)
+	io.Uint64(&x.Duration)
 }
 
 // ID ...
@@ -39,15 +52,7 @@ func (pk *ClientBoundDebugRenderer) Marshal(io protocol.IO) {
 	typStr := clientBoundDebugRenderToString(pk.Type)
 	io.String(&typStr)
 	clientBoundDebugRenderFromString(io, &pk.Type, typStr)
-	if pk.Type == ClientBoundDebugRendererAddCube {
-		io.String(&pk.Text)
-		io.Vec3(&pk.Position)
-		io.Float32(&pk.Red)
-		io.Float32(&pk.Green)
-		io.Float32(&pk.Blue)
-		io.Float32(&pk.Alpha)
-		io.Uint64(&pk.Duration)
-	}
+	protocol.OptionalMarshaler(io, &pk.Data)
 }
 
 func clientBoundDebugRenderToString(x uint32) string {


### PR DESCRIPTION
When sending `/reload` in terminal.

```
> send-command -s TESTING reload
Sent command to 'TESTING': reload
> [TESTING] [2026-07-02 11:59:38:509 INFO] Function and script files have been reloaded.
[PROXY] 2026/07/02 11:59:38 ERROR read packet: decode packet *packet.ClientBoundDebugRenderer: 1 unread bytes left: 0x00 src=dialer raddr=127.0.0.1:19134
[PROXY] 2026/07/02 11:59:38 ERROR read packet: decode packet *packet.ClientBoundDebugRenderer: 1 unread bytes left: 0x00 src=dialer raddr=127.0.0.1:19134
[PROXY] 2026/07/02 11:59:38 ERROR read packet: decode packet *packet.ClientBoundDebugRenderer: 1 unread bytes left: 0x00 src=dialer raddr=127.0.0.1:19134
[PROXY] 2026/07/02 11:59:38 ERROR read packet: decode packet *packet.ClientBoundDebugRenderer: 1 unread bytes left: 0x00 src=dialer raddr=127.0.0.1:19134
[PROXY] 2026/07/02 11:59:38 INFO reloaded commands from server count=65
```

<img width="637" height="281" alt="image" src="https://github.com/user-attachments/assets/259d9da9-b2a4-44b7-b920-747ddd5d1b32" />