### PR TITLE
protocol: handle empty telemetry event ordinals

### DIFF
--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -227,6 +227,8 @@ func lookupEventOrdinal(x Event, eventOrdinal *uint32) bool {
 		*eventOrdinal = 19
 	case *ItemUsedEvent:
 		*eventOrdinal = 20
+	case *StriderRiddenInLavaInOverworldEvent, *SneakCloseToSculkSensorEvent, *CarefulRestorationEvent:
+		*eventOrdinal = 21
 	default:
 		return false
 	}


### PR DESCRIPTION
## Summary

Map the no-payload telemetry events `StriderRiddenInLavaInOverworldEvent`, `SneakCloseToSculkSensorEvent`, and `CarefulRestorationEvent` to the `Empty` event data ordinal.

## Why

The event type enum contains these events, but `lookupEventOrdinal` did not map them to a data variant. Reading or writing a legacy telemetry event with one of these event types could therefore report an unknown event packet ordinal before reaching the empty payload marshal path.

Mojang's current `LegacyTelemetryEventPacket` schema lists `Event Data` variant ordinal 21 as `Empty`, while `Event Type` includes `StriderRiddenInLavaInOverworld`, `SneakCloseToSculkSensor`, and `CarefulRestoration`. Cloudburst also registers these three event data types with empty read/write handlers.

Evidence:
- Mojang bedrock-protocol-docs: `LegacyTelemetryEventPacket.json`
- Cloudburst protocol: `EventDataType`, `EventSerializer_v471`, `EventSerializer_v589`

## Checks

- `go test ./minecraft/protocol`
- `go test ./minecraft/protocol/packet`
- `git diff --check upstream/master..HEAD`
