### PR TITLE
minecraft/conn.go: replay RequestChunkRadius received before StartGame

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -145,8 +145,9 @@ type Conn struct {
 	loggedIn bool
 	// spawn is a bool channel indicating if the connection is currently waiting for its spawning in
 	// the world: It is completing a sequence that will result in the spawning.
-	spawn           chan struct{}
-	waitingForSpawn atomic.Bool
+	spawn            chan struct{}
+	waitingForSpawn  atomic.Bool
+	earlyChunkRadius atomic.Pointer[packetData]
 
 	// expectedIDs is a slice of packet identifiers that are next expected to arrive, until the connection is
 	// logged in.
@@ -312,6 +313,12 @@ func (conn *Conn) StartGameContext(ctx context.Context, data GameData) error {
 	}
 	conn.waitingForSpawn.Store(true)
 	conn.startGame()
+
+	if early := conn.earlyChunkRadius.Swap(nil); early != nil {
+		if err := conn.handle(early); err != nil {
+			return conn.wrap(fmt.Errorf("replay early request_chunk_radius: %w", err), "start game")
+		}
+	}
 
 	select {
 	case <-conn.ctx.Done():
@@ -656,6 +663,9 @@ func (conn *Conn) receive(data []byte) error {
 		return nil
 	}
 	if conn.loggedIn && !conn.waitingForSpawn.Load() {
+		if pkData.h.PacketID == packet.IDRequestChunkRadius && !conn.gameDataReceived.Load() {
+			conn.earlyChunkRadius.Store(pkData)
+		}
 		select {
 		case <-conn.ctx.Done():
 		case previous := <-conn.packets:


### PR DESCRIPTION
A client that sends `RequestChunkRadius` after the login sequence completes but before `StartGame()` is called has the packet routed to the user read queue, so `handleRequestChunkRadius` never runs. The client then waits forever for `ChunkRadiusUpdated`, never sends `SetLocalPlayerAsInitialised`, and `StartGame` blocks indefinitely — a deadlock with no timeout on either side.

In a plain server this window is microseconds, but on proxies (which read packets from the accepted connection while dialing the downstream server) it spans the whole downstream dial + handshake, and some clients (observed with Android/console timing) send `RequestChunkRadius` early enough to hit it.

Fix: stash such a packet and replay it through `handle()` right after `startGame()`, which expects `IDRequestChunkRadius` at that point. The packet is still delivered to the user read queue, so proxies that forward it downstream see no behavior change; servers that call `StartGame` immediately are unaffected (the stash stays nil).