### PR TITLE
Fixed float command argument type being displayed as "unknown"

### DIFF
--- a/minecraft/protocol/command.go
+++ b/minecraft/protocol/command.go
@@ -76,8 +76,8 @@ const (
 
 const (
 	CommandArgTypeInt = iota + 1
+	_
 	CommandArgTypeFloat
-	CommandArgTypeValue
 	CommandArgTypeRValue
 	CommandArgTypeWildcardInt
 	CommandArgTypeOperator


### PR DESCRIPTION
Before:
<img width="310" height="90" alt="Screenshot From 2026-07-12 04-38-41" src="https://github.com/user-attachments/assets/b8504e37-d5c7-4424-8e4f-2b63c7024b45" />
After:
<img width="310" height="90" alt="Screenshot From 2026-07-12 04-46-46" src="https://github.com/user-attachments/assets/b10714a5-f6db-4fef-89e8-58826578319d" />
