### PR TITLE
Fixed ServerBoundDataDrivenScreenClosed incorrect decoding

### DIFF
--- a/minecraft/protocol/packet/serverbound_data_driven_screen_closed.go
+++ b/minecraft/protocol/packet/serverbound_data_driven_screen_closed.go
@@ -14,8 +14,8 @@ const (
 
 // ServerBoundDataDrivenScreenClosed is sent by the client when a data-driven UI screen is closed.
 type ServerBoundDataDrivenScreenClosed struct {
-	// FormID is the optional unique instance ID of the form that was closed.
-	FormID protocol.Optional[uint32]
+	// FormID is the unique instance ID of the form that was closed.
+	FormID uint32
 	// CloseReason is the reason the screen was closed. It is one of the DataDrivenScreenCloseReason constants.
 	CloseReason string
 }
@@ -26,6 +26,6 @@ func (*ServerBoundDataDrivenScreenClosed) ID() uint32 {
 }
 
 func (pk *ServerBoundDataDrivenScreenClosed) Marshal(io protocol.IO) {
-	protocol.OptionalFunc(io, &pk.FormID, io.Uint32)
+	io.Uint32(&pk.FormID)
 	io.String(&pk.CloseReason)
 }


### PR DESCRIPTION
```
2026/07/13 01:43:05 ERROR read packet: decode packet *packet.ServerBoundDataDrivenScreenClosed: string length 99 exceeds remaining packet payload 13 "net origin"=gophertunnel src=listener src=listener raddr=127.0.0.1:51773
```