### PR TITLE
Fix modern self-signed login claims

### DIFF
--- a/minecraft/protocol/login/data.go
+++ b/minecraft/protocol/login/data.go
@@ -146,9 +146,6 @@ type ClientData struct {
 	ClientEditorConnectionIntent int
 	// ClientIsEditorCapable specifies if the client supports editor features.
 	ClientIsEditorCapable bool
-	// IsEditorMode is retained for source compatibility with older callers.
-	// Deprecated: Use ClientEditorConnectionIntent instead.
-	IsEditorMode bool `json:"-"`
 	// LanguageCode is the language code of the player. It looks like 'en_UK'. It follows the ISO language
 	// codes, but hyphens ('-') are replaced with underscores. ('_')
 	LanguageCode string

--- a/minecraft/protocol/login/data.go
+++ b/minecraft/protocol/login/data.go
@@ -140,8 +140,15 @@ type ClientData struct {
 	// GUIScale is the GUI scale of the player. It is by default 0, and is otherwise -1 or -2 for a smaller
 	// GUI scale than usual.
 	GUIScale int `json:"GuiScale"`
-	// IsEditorMode is a value to dictate if the player is in editor mode.
-	IsEditorMode bool
+	// FilterProfanity indicates if the client has profanity filtering enabled.
+	FilterProfanity bool
+	// ClientEditorConnectionIntent indicates how the client intends to connect to an editor world.
+	ClientEditorConnectionIntent int
+	// ClientIsEditorCapable specifies if the client supports editor features.
+	ClientIsEditorCapable bool
+	// IsEditorMode is retained for source compatibility with older callers.
+	// Deprecated: Use ClientEditorConnectionIntent instead.
+	IsEditorMode bool `json:"-"`
 	// LanguageCode is the language code of the player. It looks like 'en_UK'. It follows the ISO language
 	// codes, but hyphens ('-') are replaced with underscores. ('_')
 	LanguageCode string

--- a/minecraft/protocol/login/request.go
+++ b/minecraft/protocol/login/request.go
@@ -405,6 +405,7 @@ func EncodeOffline(identityData IdentityData, data ClientData, key *ecdsa.Privat
 		req.Certificate = certificate{Chain: chain{chainJWT}}
 		req.Legacy = true
 	} else {
+		claims.Audience = jwt.Audience{"api://auth-minecraft-services/multiplayer"}
 		req.Certificate = certificate{Chain: chain{""}}
 		req.Token, _ = jwt.Signed(signer).Claims(tokenClaims{
 			Claims:          claims,
@@ -447,7 +448,7 @@ type tokenClaims struct {
 	DisplayName string `json:"xname"`
 	// Identity is the UUID of the player. It is only set for offline logins where
 	// the UUID cannot be derived from the XUID.
-	Identity string `json:"identity,omitempty"`
+	Identity string `json:"leguuid,omitempty"`
 }
 
 // identityData converts the OIDC tokenClaims into IdentityData.


### PR DESCRIPTION
## Summary

- serialize the offline UUID using the modern `leguuid` claim
- include the Minecraft multiplayer audience in self-signed tokens
- replace the obsolete editor-mode property with the current profanity-filter and editor capability client-data fields

## Why

A schema-only capture from a current real Minecraft Bedrock client confirmed that the login token contains `aud` as a string set to `api://auth-minecraft-services/multiplayer`. Its client data contains `FilterProfanity`, `ClientEditorConnectionIntent`, and `ClientIsEditorCapable`, and does not contain `IsEditorMode`.

This primary wire evidence lines up with the current PrismarineJS and PMMP implementations. Cloudburst does not generate the self-signed token, and its offline-token consumer explicitly skips audience validation, so it accepts tokens both with and without `aud`.

## Sources

- [PrismarineJS modern offline token](https://github.com/PrismarineJS/bedrock-protocol/blob/c94bedee951a7c6e3f7bd4b85e0a6a27929c4501/src/handshake/login.js)
- [PrismarineJS audience fix PR](https://github.com/PrismarineJS/bedrock-protocol/pull/743)
- [Cloudburst token validation](https://github.com/CloudburstMC/Protocol/blob/f8295d3258fcb4e5c707d852dac981e964b336aa/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java)
- [PMMP self-signed JWT body](https://github.com/pmmp/BedrockProtocol/blob/8eb5a390a8d913ee54b97ac71f42899ecbb5c419/src/types/login/openid/SelfSignedJwtBody.php)
- [PMMP client data](https://github.com/pmmp/BedrockProtocol/blob/8eb5a390a8d913ee54b97ac71f42899ecbb5c419/src/types/login/clientdata/ClientData.php)
- [PocketMine self-signed validation](https://github.com/pmmp/PocketMine-MP/blob/6a7cc02e9dff59b69241aa0bcffdb9903ce86beb/src/network/mcpe/auth/AuthJwtHelper.php)

## Verification

- schema-only capture of a real Minecraft Bedrock client login
- successful real client → Oomph proxy → PocketMine-MP 5.44.3 join
- `go test ./... -count=1`
- `git diff --check`