### PR TITLE
protocol/packet: validate saved chunk count

### DIFF
--- a/minecraft/protocol/packet/network_chunk_publisher_update.go
+++ b/minecraft/protocol/packet/network_chunk_publisher_update.go
@@ -32,5 +32,10 @@ func (*NetworkChunkPublisherUpdate) ID() uint32 {
 func (pk *NetworkChunkPublisherUpdate) Marshal(io protocol.IO) {
 	io.BlockPos(&pk.Position)
 	io.Varuint32(&pk.Radius)
-	protocol.FuncSliceUint32Length(io, &pk.SavedChunks, io.ChunkPos)
+	count := uint32(len(pk.SavedChunks))
+	io.Uint32(&count)
+	if count > 9216 {
+		io.InvalidValue(count, "savedChunks", "saved chunks exceeds maximum length of 9216 chunk positions")
+	}
+	protocol.FuncSliceOfLen(io, count, &pk.SavedChunks, io.ChunkPos)
 }


### PR DESCRIPTION
## Summary

Validate NetworkChunkPublisherUpdate.SavedChunks against the protocol maximum of 9,216 entries while preserving its uncompressed uint32 length prefix.

## Why

The packet-specific maximum was not enforced when reader limits were disabled, which is the normal dialer path for clientbound packets. A malformed server packet could therefore declare an excessive saved-chunk count before decoding the entries.

Mojang documents the Server Built Chunks List with maxItems 9216 and No size compression. PMMP independently uses a little-endian uint32 count and rejects values above 9216.

## Evidence

- https://github.com/Mojang/bedrock-protocol-docs/blob/main/json/NetworkChunkPublisherUpdatePacketPayload.json
- https://github.com/pmmp/BedrockProtocol/blob/master/src/NetworkChunkPublisherUpdatePacket.php
