### PR TITLE
protocol/packet: accept UpdateBlock from clients

### DIFF
--- a/minecraft/protocol/packet/pool.go
+++ b/minecraft/protocol/packet/pool.go
@@ -299,6 +299,7 @@ func init() {
 		IDResourcePackClientResponse:        func() Packet { return &ResourcePackClientResponse{} },
 		IDText:                              func() Packet { return &Text{} },
 		IDMovePlayer:                        func() Packet { return &MovePlayer{} },
+		IDUpdateBlock:                       func() Packet { return &UpdateBlock{} },
 		IDActorEvent:                        func() Packet { return &ActorEvent{} },
 		IDInventoryTransaction:              func() Packet { return &InventoryTransaction{} },
 		IDMobEquipment:                      func() Packet { return &MobEquipment{} },


### PR DESCRIPTION
## Summary

Register UpdateBlock in the client-originating packet pool so listeners can decode it as a typed packet instead of treating packet ID 21 as unknown.

## Why

A vanilla client has been observed sending UpdateBlock after the server sends a valid InventoryTransaction. Strict listeners currently reject that packet because UpdateBlock only exists in the server-originating pool.
