### PR TITLE
minecraft/nbt: reject invalid lengths before allocation

### DIFF
--- a/minecraft/nbt/decode.go
+++ b/minecraft/nbt/decode.go
@@ -258,7 +258,7 @@ func (d *Decoder) unmarshalTag(val reflect.Value, t tagType, tagName string) err
 			return err
 		}
 		if length < 0 {
-			return InvalidLengthError{Off: d.r.off, Op: "ByteArray", N: int64(length)}
+			return BufferOverrunError{Op: "ByteArray"}
 		}
 		b := make([]byte, length)
 		if _, err := d.r.Read(b); err != nil {
@@ -341,7 +341,7 @@ func (d *Decoder) unmarshalTag(val reflect.Value, t tagType, tagName string) err
 				return BufferOverrunError{Op: "ByteSlice"}
 			}
 			if length < 0 {
-				return InvalidLengthError{Off: d.r.off, Op: "ByteSlice", N: int64(length)}
+				return BufferOverrunError{Op: "ByteSlice"}
 			}
 			if length == 0 {
 				// Empty lists are allowed to have the TAG_Byte type.
@@ -389,7 +389,7 @@ func (d *Decoder) unmarshalTag(val reflect.Value, t tagType, tagName string) err
 				return err
 			}
 			if length < 0 {
-				return InvalidLengthError{Off: d.r.off, Op: "Slice", N: int64(length)}
+				return BufferOverrunError{Op: "Slice"}
 			}
 			v := reflect.MakeSlice(sliceType, int(length), int(length))
 			for i := 0; i < int(length); i++ {

--- a/minecraft/nbt/decode.go
+++ b/minecraft/nbt/decode.go
@@ -254,6 +254,12 @@ func (d *Decoder) unmarshalTag(val reflect.Value, t tagType, tagName string) err
 		if err != nil {
 			return err
 		}
+		if err = d.checkRemaining(int(length), "ByteArray"); err != nil {
+			return err
+		}
+		if length < 0 {
+			return InvalidLengthError{Off: d.r.off, Op: "ByteArray", N: int64(length)}
+		}
 		b := make([]byte, length)
 		if _, err := d.r.Read(b); err != nil {
 			return BufferOverrunError{Op: "ByteArray"}
@@ -334,10 +340,16 @@ func (d *Decoder) unmarshalTag(val reflect.Value, t tagType, tagName string) err
 			if err != nil {
 				return BufferOverrunError{Op: "ByteSlice"}
 			}
+			if length < 0 {
+				return InvalidLengthError{Off: d.r.off, Op: "ByteSlice", N: int64(length)}
+			}
 			if length == 0 {
 				// Empty lists are allowed to have the TAG_Byte type.
 				val.Set(reflect.MakeSlice(sliceType, int(length), int(length)))
 				break
+			}
+			if err = d.checkRemaining(int(length), "ByteSlice"); err != nil {
+				return err
 			}
 			b := make([]byte, length)
 			if _, err := d.r.Read(b); err != nil {
@@ -375,6 +387,9 @@ func (d *Decoder) unmarshalTag(val reflect.Value, t tagType, tagName string) err
 			length, err := d.Encoding.Int32(d.r)
 			if err != nil {
 				return err
+			}
+			if length < 0 {
+				return InvalidLengthError{Off: d.r.off, Op: "Slice", N: int64(length)}
 			}
 			v := reflect.MakeSlice(sliceType, int(length), int(length))
 			for i := 0; i < int(length); i++ {
@@ -528,6 +543,13 @@ func (d *Decoder) tag() (t tagType, tagName string, err error) {
 		tagName, err = d.Encoding.String(d.r)
 	}
 	return t, tagName, err
+}
+
+func (d *Decoder) checkRemaining(length int, op string) error {
+	if remaining, ok := d.r.Reader.(interface{ Len() int }); ok && length > remaining.Len() {
+		return BufferOverrunError{Op: op}
+	}
+	return nil
 }
 
 // isAny checks if a reflect.Value has the type `any` or `interface{}`.

--- a/minecraft/nbt/encoding.go
+++ b/minecraft/nbt/encoding.go
@@ -191,6 +191,9 @@ func (e networkLittleEndian) Int32Slice(r *offsetReader) ([]int32, error) {
 	if err != nil {
 		return nil, BufferOverrunError{Op: "Int32Slice"}
 	}
+	if n < 0 {
+		return nil, InvalidLengthError{Off: r.off, Op: "Int32Slice", N: int64(n)}
+	}
 	m := make([]int32, n)
 	for i := int32(0); i < n; i++ {
 		m[i], err = e.Int32(r)
@@ -206,6 +209,9 @@ func (e networkLittleEndian) Int64Slice(r *offsetReader) ([]int64, error) {
 	n, err := e.Int32(r)
 	if err != nil {
 		return nil, BufferOverrunError{Op: "Int64Slice"}
+	}
+	if n < 0 {
+		return nil, InvalidLengthError{Off: r.off, Op: "Int64Slice", N: int64(n)}
 	}
 	m := make([]int64, n)
 	for i := int32(0); i < n; i++ {

--- a/minecraft/nbt/encoding.go
+++ b/minecraft/nbt/encoding.go
@@ -192,7 +192,7 @@ func (e networkLittleEndian) Int32Slice(r *offsetReader) ([]int32, error) {
 		return nil, BufferOverrunError{Op: "Int32Slice"}
 	}
 	if n < 0 {
-		return nil, InvalidLengthError{Off: r.off, Op: "Int32Slice", N: int64(n)}
+		return nil, BufferOverrunError{Op: "Int32Slice"}
 	}
 	m := make([]int32, n)
 	for i := int32(0); i < n; i++ {
@@ -211,7 +211,7 @@ func (e networkLittleEndian) Int64Slice(r *offsetReader) ([]int64, error) {
 		return nil, BufferOverrunError{Op: "Int64Slice"}
 	}
 	if n < 0 {
-		return nil, InvalidLengthError{Off: r.off, Op: "Int64Slice", N: int64(n)}
+		return nil, BufferOverrunError{Op: "Int64Slice"}
 	}
 	m := make([]int64, n)
 	for i := int32(0); i < n; i++ {

--- a/minecraft/nbt/encoding_big_endian.go
+++ b/minecraft/nbt/encoding_big_endian.go
@@ -127,6 +127,9 @@ func (e bigEndian) String(r *offsetReader) (string, error) {
 	if err != nil {
 		return "", BufferOverrunError{Op: "String"}
 	}
+	if n < 0 {
+		return "", InvalidStringError{Off: r.off, N: 0, Err: errNegativeLength}
+	}
 	b := make([]byte, uint16(n))
 	if _, err := r.Read(b); err != nil {
 		return "", BufferOverrunError{Op: "String"}
@@ -139,6 +142,9 @@ func (e bigEndian) Int32Slice(r *offsetReader) ([]int32, error) {
 	n, err := e.Int32(r)
 	if err != nil {
 		return nil, BufferOverrunError{Op: "Int32Slice"}
+	}
+	if n < 0 {
+		return nil, InvalidLengthError{Off: r.off, Op: "Int32Slice", N: int64(n)}
 	}
 	b := make([]byte, n*4)
 	if _, err := r.Read(b); err != nil {
@@ -155,6 +161,9 @@ func (e bigEndian) Int64Slice(r *offsetReader) ([]int64, error) {
 	n, err := e.Int32(r)
 	if err != nil {
 		return nil, BufferOverrunError{Op: "Int64Slice"}
+	}
+	if n < 0 {
+		return nil, InvalidLengthError{Off: r.off, Op: "Int64Slice", N: int64(n)}
 	}
 	b := make([]byte, n*8)
 	if _, err := r.Read(b); err != nil {

--- a/minecraft/nbt/encoding_big_endian.go
+++ b/minecraft/nbt/encoding_big_endian.go
@@ -128,7 +128,7 @@ func (e bigEndian) String(r *offsetReader) (string, error) {
 		return "", BufferOverrunError{Op: "String"}
 	}
 	if n < 0 {
-		return "", InvalidStringError{Off: r.off, N: 0, Err: errNegativeLength}
+		return "", BufferOverrunError{Op: "String"}
 	}
 	b := make([]byte, uint16(n))
 	if _, err := r.Read(b); err != nil {
@@ -144,7 +144,7 @@ func (e bigEndian) Int32Slice(r *offsetReader) ([]int32, error) {
 		return nil, BufferOverrunError{Op: "Int32Slice"}
 	}
 	if n < 0 {
-		return nil, InvalidLengthError{Off: r.off, Op: "Int32Slice", N: int64(n)}
+		return nil, BufferOverrunError{Op: "Int32Slice"}
 	}
 	b := make([]byte, n*4)
 	if _, err := r.Read(b); err != nil {
@@ -163,7 +163,7 @@ func (e bigEndian) Int64Slice(r *offsetReader) ([]int64, error) {
 		return nil, BufferOverrunError{Op: "Int64Slice"}
 	}
 	if n < 0 {
-		return nil, InvalidLengthError{Off: r.off, Op: "Int64Slice", N: int64(n)}
+		return nil, BufferOverrunError{Op: "Int64Slice"}
 	}
 	b := make([]byte, n*8)
 	if _, err := r.Read(b); err != nil {

--- a/minecraft/nbt/encoding_little_endian.go
+++ b/minecraft/nbt/encoding_little_endian.go
@@ -128,7 +128,7 @@ func (e littleEndian) String(r *offsetReader) (string, error) {
 		return "", BufferOverrunError{Op: "String"}
 	}
 	if strLen < 0 {
-		return "", InvalidStringError{Off: r.off, N: 0, Err: errNegativeLength}
+		return "", BufferOverrunError{Op: "String"}
 	}
 	b := make([]byte, uint16(strLen))
 	if _, err := r.Read(b); err != nil {
@@ -144,7 +144,7 @@ func (e littleEndian) Int32Slice(r *offsetReader) ([]int32, error) {
 		return nil, BufferOverrunError{Op: "Int32Slice"}
 	}
 	if n < 0 {
-		return nil, InvalidLengthError{Off: r.off, Op: "Int32Slice", N: int64(n)}
+		return nil, BufferOverrunError{Op: "Int32Slice"}
 	}
 	b := make([]byte, n*4)
 	if _, err := r.Read(b); err != nil {
@@ -163,7 +163,7 @@ func (e littleEndian) Int64Slice(r *offsetReader) ([]int64, error) {
 		return nil, BufferOverrunError{Op: "Int64Slice"}
 	}
 	if n < 0 {
-		return nil, InvalidLengthError{Off: r.off, Op: "Int64Slice", N: int64(n)}
+		return nil, BufferOverrunError{Op: "Int64Slice"}
 	}
 	b := make([]byte, n*8)
 	if _, err := r.Read(b); err != nil {

--- a/minecraft/nbt/encoding_little_endian.go
+++ b/minecraft/nbt/encoding_little_endian.go
@@ -127,6 +127,9 @@ func (e littleEndian) String(r *offsetReader) (string, error) {
 	if err != nil {
 		return "", BufferOverrunError{Op: "String"}
 	}
+	if strLen < 0 {
+		return "", InvalidStringError{Off: r.off, N: 0, Err: errNegativeLength}
+	}
 	b := make([]byte, uint16(strLen))
 	if _, err := r.Read(b); err != nil {
 		return "", BufferOverrunError{Op: "String"}
@@ -139,6 +142,9 @@ func (e littleEndian) Int32Slice(r *offsetReader) ([]int32, error) {
 	n, err := e.Int32(r)
 	if err != nil {
 		return nil, BufferOverrunError{Op: "Int32Slice"}
+	}
+	if n < 0 {
+		return nil, InvalidLengthError{Off: r.off, Op: "Int32Slice", N: int64(n)}
 	}
 	b := make([]byte, n*4)
 	if _, err := r.Read(b); err != nil {
@@ -155,6 +161,9 @@ func (e littleEndian) Int64Slice(r *offsetReader) ([]int64, error) {
 	n, err := e.Int32(r)
 	if err != nil {
 		return nil, BufferOverrunError{Op: "Int64Slice"}
+	}
+	if n < 0 {
+		return nil, InvalidLengthError{Off: r.off, Op: "Int64Slice", N: int64(n)}
 	}
 	b := make([]byte, n*8)
 	if _, err := r.Read(b); err != nil {

--- a/minecraft/nbt/err.go
+++ b/minecraft/nbt/err.go
@@ -119,6 +119,7 @@ func (err IncompatibleTypeError) Error() string {
 }
 
 var errStringTooLong = errors.New("string length exceeds maximum length")
+var errNegativeLength = errors.New("negative length")
 
 // InvalidStringError is returned if a string read is not valid, meaning it does not exist exclusively out of
 // utf8 characters, or if it is longer than the length prefix can carry.
@@ -131,6 +132,19 @@ type InvalidStringError struct {
 // Error ...
 func (err InvalidStringError) Error() string {
 	return fmt.Sprintf("nbt: string at offset %v is not valid: %v (len=%v)", err.Off, err.Err, err.N)
+}
+
+// InvalidLengthError is returned when a negative length is read from NBT data for an array/slice/string/list.
+// Some implementations may send malformed or truncated NBT, and Go's slice/array allocation would panic.
+type InvalidLengthError struct {
+	Off int64
+	Op  string
+	N   int64
+}
+
+// Error ...
+func (err InvalidLengthError) Error() string {
+	return fmt.Sprintf("nbt: invalid length at offset %v during op '%v': %v", err.Off, err.Op, err.N)
 }
 
 const maximumNestingDepth = 512

--- a/minecraft/nbt/err.go
+++ b/minecraft/nbt/err.go
@@ -119,7 +119,6 @@ func (err IncompatibleTypeError) Error() string {
 }
 
 var errStringTooLong = errors.New("string length exceeds maximum length")
-var errNegativeLength = errors.New("negative length")
 
 // InvalidStringError is returned if a string read is not valid, meaning it does not exist exclusively out of
 // utf8 characters, or if it is longer than the length prefix can carry.
@@ -132,19 +131,6 @@ type InvalidStringError struct {
 // Error ...
 func (err InvalidStringError) Error() string {
 	return fmt.Sprintf("nbt: string at offset %v is not valid: %v (len=%v)", err.Off, err.Err, err.N)
-}
-
-// InvalidLengthError is returned when a negative length is read from NBT data for an array/slice/string/list.
-// Some implementations may send malformed or truncated NBT, and Go's slice/array allocation would panic.
-type InvalidLengthError struct {
-	Off int64
-	Op  string
-	N   int64
-}
-
-// Error ...
-func (err InvalidLengthError) Error() string {
-	return fmt.Sprintf("nbt: invalid length at offset %v during op '%v': %v", err.Off, err.Op, err.N)
 }
 
 const maximumNestingDepth = 512


### PR DESCRIPTION
## Summary

- reject negative NBT array, list, string, and integer-slice lengths before allocation
- reject byte-array and byte-list lengths that exceed the remaining buffered payload
- report malformed lengths using the existing BufferOverrunError type

## Why

Malformed NBT length prefixes currently reach make, reflect.MakeSlice, or reflect.ArrayOf first. Negative values can panic, while impossible positive byte lengths can allocate based on attacker-controlled input before the decoder discovers that the payload is truncated.

The checks return the package's existing decode error before those allocations. Remaining-payload validation is conditional on the input exposing Len, preserving support for streaming readers without introducing a new public error API.

## Evidence

- Negative-length handling: https://github.com/moon-committee/gophertunnel/commit/bba0a4022343abe453fd6fa9c4749d85017091a8
- Remaining-payload handling: https://github.com/moon-committee/gophertunnel/commit/1d1cbca87d0d24449de944f282f7c948cbee1753

## Validation

- go test ./minecraft/nbt
- go test ./...
- git diff --check upstream/master

No test or documentation files are included in this PR.
