### PR TITLE
minecraft/protocol/packet: Add TranslateEntityIDs

### DIFF
--- a/minecraft/protocol/packet/translate.go
+++ b/minecraft/protocol/packet/translate.go
@@ -1,0 +1,270 @@
+package packet
+
+import (
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+)
+
+// entityMetadataIDKeys holds the entity metadata keys whose values are entity unique IDs.
+var entityMetadataIDKeys = []uint32{
+	protocol.EntityDataKeyOwner,
+	protocol.EntityDataKeyTarget,
+	protocol.EntityDataKeyLeashHolder,
+	protocol.EntityDataKeyTargetA,
+	protocol.EntityDataKeyTargetB,
+	protocol.EntityDataKeyTargetC,
+	protocol.EntityDataKeyTradeTarget,
+	protocol.EntityDataKeyBalloonAnchor,
+	protocol.EntityDataKeyAgent,
+	protocol.EntityDataKeyAimAssistPriorityActorID,
+	protocol.EntityDataKeyArrowShooterID,
+	protocol.EntityDataKeyFireworkShooterID,
+}
+
+// TranslateEntityIDs passes every entity runtime ID and entity unique ID carried by pk,
+// including IDs nested in structures such as entity links or metadata, through runtimeID
+// and uniqueID respectively, storing the results. Either function may be nil to leave IDs
+// of that kind untouched. The callbacks decide the mapping policy and must return their
+// argument unchanged for IDs they do not translate, such as sentinel values like
+// math.MaxInt64. Runtime IDs held in uint32 fields are truncated to their width.
+func TranslateEntityIDs(pk Packet, runtimeID func(uint64) uint64, uniqueID func(int64) int64) {
+	rid := runtimeID
+	if rid == nil {
+		rid = func(id uint64) uint64 { return id }
+	}
+	uid := uniqueID
+	if uid == nil {
+		uid = func(id int64) int64 { return id }
+	}
+	entityLink := func(link protocol.EntityLink) protocol.EntityLink {
+		link.RiddenEntityUniqueID = uid(link.RiddenEntityUniqueID)
+		link.RiderEntityUniqueID = uid(link.RiderEntityUniqueID)
+		return link
+	}
+	metadata := func(values map[uint32]any) {
+		for _, key := range entityMetadataIDKeys {
+			switch id := values[key].(type) {
+			case int64:
+				values[key] = uid(id)
+			case uint64:
+				values[key] = uint64(uid(int64(id)))
+			}
+		}
+	}
+
+	switch pk := pk.(type) {
+	case *ActorEvent:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *ActorPickRequest:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *AgentAnimation:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *AddActor:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+		metadata(pk.EntityMetadata)
+		for i := range pk.EntityLinks {
+			pk.EntityLinks[i] = entityLink(pk.EntityLinks[i])
+		}
+	case *AddItemActor:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+		metadata(pk.EntityMetadata)
+	case *AddPainting:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *AddPlayer:
+		pk.AbilityData.EntityUniqueID = uid(pk.AbilityData.EntityUniqueID)
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+		metadata(pk.EntityMetadata)
+		for i := range pk.EntityLinks {
+			pk.EntityLinks[i] = entityLink(pk.EntityLinks[i])
+		}
+	case *AddVolumeEntity:
+		pk.EntityRuntimeID = uint32(rid(uint64(pk.EntityRuntimeID)))
+	case *AdventureSettings:
+		pk.PlayerUniqueID = uid(pk.PlayerUniqueID)
+	case *Animate:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *AnimateEntity:
+		for i := range pk.EntityRuntimeIDs {
+			pk.EntityRuntimeIDs[i] = rid(pk.EntityRuntimeIDs[i])
+		}
+	case *BossEvent:
+		pk.BossEntityUniqueID = uid(pk.BossEntityUniqueID)
+		pk.PlayerUniqueID = uid(pk.PlayerUniqueID)
+	case *Camera:
+		pk.CameraEntityUniqueID = uid(pk.CameraEntityUniqueID)
+		pk.TargetPlayerUniqueID = uid(pk.TargetPlayerUniqueID)
+	case *CameraInstruction:
+		if target, ok := pk.Target.Value(); ok {
+			target.EntityUniqueID = uid(target.EntityUniqueID)
+			pk.Target = protocol.Option(target)
+		}
+		if attached, ok := pk.AttachToEntity.Value(); ok {
+			pk.AttachToEntity = protocol.Option(uid(attached))
+		}
+	case *ChangeMobProperty:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *ClientBoundMapItemData:
+		for i := range pk.TrackedObjects {
+			if pk.TrackedObjects[i].Type == protocol.MapObjectTypeEntity {
+				pk.TrackedObjects[i].EntityUniqueID = uid(pk.TrackedObjects[i].EntityUniqueID)
+			}
+		}
+	case *ClientCheatAbility:
+		pk.AbilityData.EntityUniqueID = uid(pk.AbilityData.EntityUniqueID)
+	case *ClientMovementPredictionSync:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *CommandBlockUpdate:
+		if !pk.Block {
+			pk.MinecartEntityRuntimeID = rid(pk.MinecartEntityRuntimeID)
+		}
+	case *CommandOutput:
+		pk.CommandOrigin.PlayerUniqueID = uid(pk.CommandOrigin.PlayerUniqueID)
+	case *CommandRequest:
+		pk.CommandOrigin.PlayerUniqueID = uid(pk.CommandOrigin.PlayerUniqueID)
+	case *ContainerOpen:
+		pk.ContainerEntityUniqueID = uid(pk.ContainerEntityUniqueID)
+	case *CreatePhoto:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *DebugInfo:
+		pk.PlayerUniqueID = uid(pk.PlayerUniqueID)
+	case *Emote:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *EmoteList:
+		pk.PlayerRuntimeID = rid(pk.PlayerRuntimeID)
+	case *Event:
+		pk.EntityRuntimeID = int64(rid(uint64(pk.EntityRuntimeID)))
+		switch event := pk.Event.(type) {
+		case *protocol.MobKilledEvent:
+			event.KillerEntityUniqueID = uid(event.KillerEntityUniqueID)
+			event.VictimEntityUniqueID = uid(event.VictimEntityUniqueID)
+		case *protocol.BossKilledEvent:
+			event.BossEntityUniqueID = uid(event.BossEntityUniqueID)
+		case *protocol.EntityInteractEvent:
+			event.InteractedEntityID = uid(event.InteractedEntityID)
+		}
+	case *Interact:
+		pk.TargetEntityRuntimeID = rid(pk.TargetEntityRuntimeID)
+	case *InventoryTransaction:
+		if data, ok := pk.TransactionData.(*protocol.UseItemOnEntityTransactionData); ok {
+			data.TargetEntityRuntimeID = rid(data.TargetEntityRuntimeID)
+		}
+	case *LevelSoundEvent:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *LocatorBar:
+		for i := range pk.Waypoints {
+			if id, ok := pk.Waypoints[i].Waypoint.ActorUniqueID.Value(); ok {
+				pk.Waypoints[i].Waypoint.ActorUniqueID = protocol.Option(uid(id))
+			}
+		}
+	case *MobArmourEquipment:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *MobEffect:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *MobEquipment:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *MotionPredictionHints:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *MovementEffect:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *MoveActorAbsolute:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *MoveActorDelta:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *MovePlayer:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+		pk.RiddenEntityRuntimeID = rid(pk.RiddenEntityRuntimeID)
+	case *NPCDialogue:
+		pk.EntityUniqueID = uint64(uid(int64(pk.EntityUniqueID)))
+	case *NPCRequest:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *PhotoTransfer:
+		pk.OwnerEntityUniqueID = uid(pk.OwnerEntityUniqueID)
+	case *PlayerAction:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *PlayerAuthInput:
+		if pk.InputData.Load(InputFlagClientPredictedVehicle) {
+			pk.ClientPredictedVehicle = uid(pk.ClientPredictedVehicle)
+		}
+	case *PlayerLocation:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *PlayerList:
+		for i := range pk.Entries {
+			pk.Entries[i].EntityUniqueID = uid(pk.Entries[i].EntityUniqueID)
+		}
+	case *PlayerUpdateEntityOverrides:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *PrimitiveShapes:
+		for i := range pk.Shapes {
+			if id, ok := pk.Shapes[i].AttachedToEntityID.Value(); ok {
+				pk.Shapes[i].AttachedToEntityID = protocol.Option(uid(id))
+			}
+		}
+	case *RemoveActor:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *RemoveVolumeEntity:
+		pk.EntityRuntimeID = uint32(rid(uint64(pk.EntityRuntimeID)))
+	case *Respawn:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *RequestPermissions:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *SetActorData:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+		metadata(pk.EntityMetadata)
+	case *SetActorLink:
+		pk.EntityLink = entityLink(pk.EntityLink)
+	case *SetActorMotion:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *SetLocalPlayerAsInitialised:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *SetScore:
+		for i := range pk.Entries {
+			if pk.Entries[i].IdentityType != protocol.ScoreboardIdentityFakePlayer {
+				pk.Entries[i].EntityUniqueID = uid(pk.Entries[i].EntityUniqueID)
+			}
+		}
+	case *SetScoreboardIdentity:
+		if pk.ActionType != ScoreboardIdentityActionClear {
+			for i := range pk.Entries {
+				pk.Entries[i].EntityUniqueID = uid(pk.Entries[i].EntityUniqueID)
+			}
+		}
+	case *ShowCredits:
+		pk.PlayerRuntimeID = rid(pk.PlayerRuntimeID)
+	case *SpawnParticleEffect:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *StartGame:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *StructureBlockUpdate:
+		pk.Settings.LastEditingPlayerUniqueID = uid(pk.Settings.LastEditingPlayerUniqueID)
+	case *StructureTemplateDataRequest:
+		pk.Settings.LastEditingPlayerUniqueID = uid(pk.Settings.LastEditingPlayerUniqueID)
+	case *TakeItemActor:
+		pk.ItemEntityRuntimeID = rid(pk.ItemEntityRuntimeID)
+		pk.TakerEntityRuntimeID = rid(pk.TakerEntityRuntimeID)
+	case *UpdateAttributes:
+		pk.EntityRuntimeID = rid(pk.EntityRuntimeID)
+	case *UpdateAbilities:
+		pk.AbilityData.EntityUniqueID = uid(pk.AbilityData.EntityUniqueID)
+	case *UpdateBlockSynced:
+		pk.EntityUniqueID = uint64(uid(int64(pk.EntityUniqueID)))
+	case *UpdateEquip:
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	case *UpdatePlayerGameType:
+		pk.PlayerUniqueID = uid(pk.PlayerUniqueID)
+	case *UpdateSubChunkBlocks:
+		for i := range pk.Blocks {
+			pk.Blocks[i].SyncedUpdateEntityUniqueID =
+				uint64(uid(int64(pk.Blocks[i].SyncedUpdateEntityUniqueID)))
+		}
+		for i := range pk.Extra {
+			pk.Extra[i].SyncedUpdateEntityUniqueID =
+				uint64(uid(int64(pk.Extra[i].SyncedUpdateEntityUniqueID)))
+		}
+	case *UpdateTrade:
+		pk.VillagerUniqueID = uid(pk.VillagerUniqueID)
+		pk.EntityUniqueID = uid(pk.EntityUniqueID)
+	}
+}

--- a/minecraft/protocol/packet/translate_test.go
+++ b/minecraft/protocol/packet/translate_test.go
@@ -1,0 +1,350 @@
+package packet
+
+import (
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+)
+
+// idFieldPattern matches struct field names that suggest the field carries an entity
+// runtime or unique ID. Fields named after their meaning rather than their ID kind are
+// listed explicitly.
+var idFieldPattern = regexp.MustCompile(`RuntimeID|UniqueID|ActorID|EntityID|ClientPredictedVehicle|AttachToEntity`)
+
+// translatedIDFields lists every entity ID field, as a path from the packet struct, that
+// TranslateEntityIDs rewrites and that idFieldPattern can discover. IDs behind interface
+// fields and entity metadata map values are translated but not discoverable.
+var translatedIDFields = []string{
+	"ActorEvent.EntityRuntimeID",
+	"ActorPickRequest.EntityUniqueID",
+	"AddActor.EntityLinks[].RiddenEntityUniqueID",
+	"AddActor.EntityLinks[].RiderEntityUniqueID",
+	"AddActor.EntityRuntimeID",
+	"AddActor.EntityUniqueID",
+	"AddItemActor.EntityRuntimeID",
+	"AddItemActor.EntityUniqueID",
+	"AddPainting.EntityRuntimeID",
+	"AddPainting.EntityUniqueID",
+	"AddPlayer.AbilityData.EntityUniqueID",
+	"AddPlayer.EntityLinks[].RiddenEntityUniqueID",
+	"AddPlayer.EntityLinks[].RiderEntityUniqueID",
+	"AddPlayer.EntityRuntimeID",
+	"AddVolumeEntity.EntityRuntimeID",
+	"AdventureSettings.PlayerUniqueID",
+	"AgentAnimation.EntityRuntimeID",
+	"Animate.EntityRuntimeID",
+	"AnimateEntity.EntityRuntimeIDs",
+	"BossEvent.BossEntityUniqueID",
+	"BossEvent.PlayerUniqueID",
+	"Camera.CameraEntityUniqueID",
+	"Camera.TargetPlayerUniqueID",
+	"CameraInstruction.AttachToEntity",
+	"CameraInstruction.Target.EntityUniqueID",
+	"ChangeMobProperty.EntityUniqueID",
+	"ClientBoundMapItemData.TrackedObjects[].EntityUniqueID",
+	"ClientCheatAbility.AbilityData.EntityUniqueID",
+	"ClientMovementPredictionSync.EntityUniqueID",
+	"CommandBlockUpdate.MinecartEntityRuntimeID",
+	"CommandOutput.CommandOrigin.PlayerUniqueID",
+	"CommandRequest.CommandOrigin.PlayerUniqueID",
+	"ContainerOpen.ContainerEntityUniqueID",
+	"CreatePhoto.EntityUniqueID",
+	"DebugInfo.PlayerUniqueID",
+	"Emote.EntityRuntimeID",
+	"EmoteList.PlayerRuntimeID",
+	"Event.EntityRuntimeID",
+	"Interact.TargetEntityRuntimeID",
+	"LevelSoundEvent.EntityUniqueID",
+	"LocatorBar.Waypoints[].Waypoint.ActorUniqueID",
+	"MobArmourEquipment.EntityRuntimeID",
+	"MobEffect.EntityRuntimeID",
+	"MobEquipment.EntityRuntimeID",
+	"MotionPredictionHints.EntityRuntimeID",
+	"MoveActorAbsolute.EntityRuntimeID",
+	"MoveActorDelta.EntityRuntimeID",
+	"MovePlayer.EntityRuntimeID",
+	"MovePlayer.RiddenEntityRuntimeID",
+	"MovementEffect.EntityRuntimeID",
+	"NPCDialogue.EntityUniqueID",
+	"NPCRequest.EntityRuntimeID",
+	"PhotoTransfer.OwnerEntityUniqueID",
+	"PlayerAction.EntityRuntimeID",
+	"PlayerAuthInput.ClientPredictedVehicle",
+	"PlayerList.Entries[].EntityUniqueID",
+	"PlayerLocation.EntityUniqueID",
+	"PlayerUpdateEntityOverrides.EntityUniqueID",
+	"PrimitiveShapes.Shapes[].AttachedToEntityID",
+	"RemoveActor.EntityUniqueID",
+	"RemoveVolumeEntity.EntityRuntimeID",
+	"RequestPermissions.EntityUniqueID",
+	"Respawn.EntityRuntimeID",
+	"SetActorData.EntityRuntimeID",
+	"SetActorLink.EntityLink.RiddenEntityUniqueID",
+	"SetActorLink.EntityLink.RiderEntityUniqueID",
+	"SetActorMotion.EntityRuntimeID",
+	"SetLocalPlayerAsInitialised.EntityRuntimeID",
+	"SetScore.Entries[].EntityUniqueID",
+	"SetScoreboardIdentity.Entries[].EntityUniqueID",
+	"ShowCredits.PlayerRuntimeID",
+	"SpawnParticleEffect.EntityUniqueID",
+	"StartGame.EntityRuntimeID",
+	"StartGame.EntityUniqueID",
+	"StructureBlockUpdate.Settings.LastEditingPlayerUniqueID",
+	"StructureTemplateDataRequest.Settings.LastEditingPlayerUniqueID",
+	"TakeItemActor.ItemEntityRuntimeID",
+	"TakeItemActor.TakerEntityRuntimeID",
+	"UpdateAbilities.AbilityData.EntityUniqueID",
+	"UpdateAttributes.EntityRuntimeID",
+	"UpdateBlockSynced.EntityUniqueID",
+	"UpdateEquip.EntityUniqueID",
+	"UpdatePlayerGameType.PlayerUniqueID",
+	"UpdateSubChunkBlocks.Blocks[].SyncedUpdateEntityUniqueID",
+	"UpdateSubChunkBlocks.Extra[].SyncedUpdateEntityUniqueID",
+	"UpdateTrade.EntityUniqueID",
+	"UpdateTrade.VillagerUniqueID",
+}
+
+// ignoredIDFields lists fields matched by the naming heuristic that TranslateEntityIDs
+// deliberately leaves untouched, with the reason.
+var ignoredIDFields = map[string]string{
+	"ItemRegistry.Items[].RuntimeID": "item type network ID, not an entity ID",
+}
+
+// TestTranslateEntityIDsCoverage fails when a packet field that looks like an entity ID
+// is neither translated nor deliberately ignored, so that a protocol update adding one
+// breaks this test until TranslateEntityIDs is brought back in sync. Block runtime IDs
+// are out of scope; interface implementations carrying entity IDs must be covered by
+// hand.
+func TestTranslateEntityIDsCoverage(t *testing.T) {
+	discovered := map[string]bool{}
+	seen := map[reflect.Type]bool{}
+	for _, pool := range []Pool{NewClientPool(), NewServerPool()} {
+		for _, newPk := range pool {
+			typ := reflect.TypeOf(newPk()).Elem()
+			if seen[typ] {
+				continue
+			}
+			seen[typ] = true
+			walkIDFields(typ, typ.Name(), discovered, map[reflect.Type]bool{})
+		}
+	}
+
+	expected := map[string]bool{}
+	for _, path := range translatedIDFields {
+		expected[path] = true
+	}
+	for path := range ignoredIDFields {
+		expected[path] = true
+	}
+
+	var missing, stale []string
+	for path := range discovered {
+		if !expected[path] {
+			missing = append(missing, path)
+		}
+	}
+	for path := range expected {
+		if !discovered[path] {
+			stale = append(stale, path)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(stale)
+	for _, path := range missing {
+		t.Errorf("entity ID field %v is neither translated by TranslateEntityIDs nor listed as ignored", path)
+	}
+	for _, path := range stale {
+		t.Errorf("listed entity ID field %v no longer exists in the packet package", path)
+	}
+}
+
+// walkIDFields recursively collects the paths of ID-like fields of a packet struct type,
+// reporting fields of protocol.Optional types as the optional field itself.
+func walkIDFields(typ reflect.Type, path string, found map[string]bool, visiting map[reflect.Type]bool) {
+	switch typ.Kind() {
+	case reflect.Pointer, reflect.Slice, reflect.Array:
+		walkIDFields(typ.Elem(), path+"[]", found, visiting)
+	case reflect.Map:
+		walkIDFields(typ.Elem(), path+"{}", found, visiting)
+	case reflect.Struct:
+		if visiting[typ] {
+			return
+		}
+		visiting[typ] = true
+		defer delete(visiting, typ)
+		optional := strings.HasPrefix(typ.Name(), "Optional[")
+		for field := range typ.Fields() {
+			fieldPath := path + "." + field.Name
+			if optional {
+				fieldPath = path
+			}
+			if !optional && idFieldPattern.MatchString(field.Name) && !strings.Contains(field.Name, "BlockRuntimeID") {
+				found[fieldPath] = true
+				continue
+			}
+			walkIDFields(field.Type, fieldPath, found, visiting)
+		}
+	}
+}
+
+// translateSwap swaps between the (10, 100) and (20, 200) (unique, runtime) identities.
+func translateSwap(pk Packet) {
+	rid := func(id uint64) uint64 {
+		switch id {
+		case 100:
+			return 200
+		case 200:
+			return 100
+		}
+		return id
+	}
+	uid := func(id int64) int64 {
+		switch id {
+		case 10:
+			return 20
+		case 20:
+			return 10
+		}
+		return id
+	}
+	TranslateEntityIDs(pk, rid, uid)
+}
+
+func TestTranslateEntityIDsSimpleFields(t *testing.T) {
+	pk := &StartGame{EntityUniqueID: 10, EntityRuntimeID: 200}
+	translateSwap(pk)
+	if pk.EntityUniqueID != 20 || pk.EntityRuntimeID != 100 {
+		t.Errorf("unexpected IDs after translation: unique %v, runtime %v", pk.EntityUniqueID, pk.EntityRuntimeID)
+	}
+	move := &MovePlayer{EntityRuntimeID: 100, RiddenEntityRuntimeID: 300}
+	translateSwap(move)
+	if move.EntityRuntimeID != 200 || move.RiddenEntityRuntimeID != 300 {
+		t.Errorf("unexpected IDs after translation: runtime %v, ridden %v", move.EntityRuntimeID, move.RiddenEntityRuntimeID)
+	}
+}
+
+func TestTranslateEntityIDsNilCallbacks(t *testing.T) {
+	pk := &StartGame{EntityUniqueID: 10, EntityRuntimeID: 100}
+	TranslateEntityIDs(pk, nil, nil)
+	if pk.EntityUniqueID != 10 || pk.EntityRuntimeID != 100 {
+		t.Errorf("nil callbacks changed IDs: unique %v, runtime %v", pk.EntityUniqueID, pk.EntityRuntimeID)
+	}
+}
+
+func TestTranslateEntityIDsMetadataAndLinks(t *testing.T) {
+	pk := &AddActor{
+		EntityUniqueID:  10,
+		EntityRuntimeID: 100,
+		EntityMetadata: map[uint32]any{
+			protocol.EntityDataKeyOwner:                    int64(10),
+			protocol.EntityDataKeyTarget:                   uint64(20),
+			protocol.EntityDataKeyLeashHolder:              int64(30),
+			protocol.EntityDataKeyAimAssistPriorityActorID: int64(20),
+			protocol.EntityDataKeyName:                     "unrelated",
+		},
+		EntityLinks: []protocol.EntityLink{{RiddenEntityUniqueID: 20, RiderEntityUniqueID: 10}},
+	}
+	translateSwap(pk)
+	if pk.EntityUniqueID != 20 || pk.EntityRuntimeID != 200 {
+		t.Errorf("unexpected IDs after translation: unique %v, runtime %v", pk.EntityUniqueID, pk.EntityRuntimeID)
+	}
+	if owner := pk.EntityMetadata[protocol.EntityDataKeyOwner]; owner != int64(20) {
+		t.Errorf("unexpected owner metadata after translation: %v", owner)
+	}
+	if target := pk.EntityMetadata[protocol.EntityDataKeyTarget]; target != uint64(10) {
+		t.Errorf("unexpected target metadata after translation: %v", target)
+	}
+	if holder := pk.EntityMetadata[protocol.EntityDataKeyLeashHolder]; holder != int64(30) {
+		t.Errorf("unexpected leash holder metadata after translation: %v", holder)
+	}
+	if aim := pk.EntityMetadata[protocol.EntityDataKeyAimAssistPriorityActorID]; aim != int64(10) {
+		t.Errorf("unexpected aim assist actor metadata after translation: %v", aim)
+	}
+	if link := pk.EntityLinks[0]; link.RiddenEntityUniqueID != 10 || link.RiderEntityUniqueID != 20 {
+		t.Errorf("unexpected entity link after translation: %+v", link)
+	}
+}
+
+func TestTranslateEntityIDsConditionalFields(t *testing.T) {
+	block := &CommandBlockUpdate{Block: true, MinecartEntityRuntimeID: 100}
+	translateSwap(block)
+	if block.MinecartEntityRuntimeID != 100 {
+		t.Errorf("block-mode CommandBlockUpdate minecart ID translated to %v", block.MinecartEntityRuntimeID)
+	}
+	minecart := &CommandBlockUpdate{Block: false, MinecartEntityRuntimeID: 100}
+	translateSwap(minecart)
+	if minecart.MinecartEntityRuntimeID != 200 {
+		t.Errorf("minecart CommandBlockUpdate ID not translated: %v", minecart.MinecartEntityRuntimeID)
+	}
+
+	input := &PlayerAuthInput{ClientPredictedVehicle: 10, InputData: protocol.NewBitset(PlayerAuthInputBitsetSize)}
+	translateSwap(input)
+	if input.ClientPredictedVehicle != 10 {
+		t.Errorf("predicted vehicle translated without its input flag: %v", input.ClientPredictedVehicle)
+	}
+	input.InputData.Set(InputFlagClientPredictedVehicle)
+	translateSwap(input)
+	if input.ClientPredictedVehicle != 20 {
+		t.Errorf("predicted vehicle not translated with its input flag: %v", input.ClientPredictedVehicle)
+	}
+
+	score := &SetScore{Entries: []protocol.ScoreboardEntry{
+		{IdentityType: protocol.ScoreboardIdentityPlayer, EntityUniqueID: 10},
+		{IdentityType: protocol.ScoreboardIdentityFakePlayer, EntityUniqueID: 10},
+	}}
+	translateSwap(score)
+	if score.Entries[0].EntityUniqueID != 20 {
+		t.Errorf("player scoreboard entry not translated: %v", score.Entries[0].EntityUniqueID)
+	}
+	if score.Entries[1].EntityUniqueID != 10 {
+		t.Errorf("fake player scoreboard entry translated: %v", score.Entries[1].EntityUniqueID)
+	}
+}
+
+func TestTranslateEntityIDsInterfaceFields(t *testing.T) {
+	tx := &InventoryTransaction{TransactionData: &protocol.UseItemOnEntityTransactionData{TargetEntityRuntimeID: 100}}
+	translateSwap(tx)
+	if id := tx.TransactionData.(*protocol.UseItemOnEntityTransactionData).TargetEntityRuntimeID; id != 200 {
+		t.Errorf("use item on entity target not translated: %v", id)
+	}
+
+	event := &Event{EntityRuntimeID: 100, Event: &protocol.MobKilledEvent{KillerEntityUniqueID: 10, VictimEntityUniqueID: 20}}
+	translateSwap(event)
+	if event.EntityRuntimeID != 200 {
+		t.Errorf("event runtime ID not translated: %v", event.EntityRuntimeID)
+	}
+	killed := event.Event.(*protocol.MobKilledEvent)
+	if killed.KillerEntityUniqueID != 20 || killed.VictimEntityUniqueID != 10 {
+		t.Errorf("mob killed event not translated: %+v", killed)
+	}
+
+	interact := &Event{Event: &protocol.EntityInteractEvent{InteractedEntityID: 10}}
+	translateSwap(interact)
+	if id := interact.Event.(*protocol.EntityInteractEvent).InteractedEntityID; id != 20 {
+		t.Errorf("entity interact event not translated: %v", id)
+	}
+}
+
+func TestTranslateEntityIDsOptionalFields(t *testing.T) {
+	camera := &CameraInstruction{
+		Target:         protocol.Option(protocol.CameraInstructionTarget{EntityUniqueID: 10}),
+		AttachToEntity: protocol.Option(int64(20)),
+	}
+	translateSwap(camera)
+	if target, _ := camera.Target.Value(); target.EntityUniqueID != 20 {
+		t.Errorf("camera target not translated: %v", target.EntityUniqueID)
+	}
+	if attached, _ := camera.AttachToEntity.Value(); attached != 10 {
+		t.Errorf("camera attach entity not translated: %v", attached)
+	}
+
+	empty := &CameraInstruction{}
+	translateSwap(empty)
+	if _, ok := empty.Target.Value(); ok {
+		t.Error("empty camera target became set")
+	}
+}


### PR DESCRIPTION
Proxies that splice an existing client connection onto a new/replacement server connection (fast transfer, seamless relog) must rewrite entity runtime and unique IDs in both directions, so the identity the client retains from its original StartGame stays stable while the server-side identity changes. Every proxy built on gophertunnel ends up maintaining its own hand-rolled packet switch for this, and those switches silently go stale whenever a protocol update adds an ID-bearing field.

This adds `packet.TranslateEntityIDs(pk, runtimeID, uniqueID)`, a policy-free visitor that enumerates every entity ID a packet carries and passes each through the caller's callbacks. The mapping policy (symmetric swap, sentinel handling, dropping self-referential packets) stays entirely with the caller, so differently-behaving proxies can share the one enumeration. Coverage includes the non-obvious carriers: entity metadata keys holding actor IDs, `EntityLink`s, ability data, command origins, scoreboard entries (skipping fake-player identities), map tracked objects, camera targets/attachments, locator bar waypoints, debug shapes, `UseItemOnEntityTransactionData`, event data (`MobKilledEvent`, `BossKilledEvent`, `EntityInteractEvent`), and conditional fields such as `CommandBlockUpdate` in minecart mode and `PlayerAuthInput.ClientPredictedVehicle` behind its input flag.

To keep the table from going stale, `TestTranslateEntityIDsCoverage` reflectively walks every registered packet struct and fails when a field whose name looks like an entity ID is neither in the translated manifest nor the explicitly-ignored list — so a protocol bump that adds an ID-bearing field breaks the test until the visitor is updated, instead of silently leaking an untranslated ID. Behavioral tests cover the swap policy, nil callbacks, metadata/links, conditional cases, interface data and `Optional` fields.