### PR TITLE
minecraft: Add resource pack caching and configurable delivery

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -172,6 +172,10 @@ type Conn struct {
 	// ignoredResourcePacks is a slice of resource packs that are not being downloaded due to the downloadResourcePack
 	// func returning false for the specific pack.
 	ignoredResourcePacks []exemptedResourcePack
+	// resourcePackCache, if set, stores resource packs downloaded by a Dialer for reuse on later logins.
+	resourcePackCache ResourcePackCache
+	// resourcePackDelivery controls how a Listener connection sends resource pack data.
+	resourcePackDelivery ResourcePackDeliveryConfig
 
 	cacheEnabled bool
 
@@ -210,6 +214,8 @@ func newConn(netConn net.Conn, key *ecdsa.PrivateKey, log *slog.Logger, proto Pr
 		hdr:          &packet.Header{},
 		proto:        proto,
 		readerLimits: limits,
+
+		resourcePackDelivery: ResourcePackDeliveryConfig{}.normalized(),
 	}
 	if d, ok := netConn.(packet.EncryptionDisabler); ok {
 		conn.disableEncryption = d.DisableEncryption()
@@ -983,6 +989,26 @@ func (conn *Conn) handleResourcePacksInfo(pk *packet.ResourcePacksInfo) error {
 			conn.packQueue.packAmount--
 			continue
 		}
+
+		cacheKey := ResourcePackCacheKey{
+			UUID:    pack.UUID,
+			Version: pack.Version,
+			Size:    pack.Size,
+		}
+		if conn.resourcePackCache != nil {
+			cachedPack, err := conn.resourcePackCache.Load(conn.ctx, cacheKey)
+			switch {
+			case err != nil:
+				conn.log.Warn("handle ResourcePacksInfo: failed to load resource pack from cache", "UUID", pack.UUID, "version", pack.Version, "err", err)
+			case cachedPack != nil && !cacheKey.Matches(cachedPack):
+				conn.log.Warn("handle ResourcePacksInfo: cached resource pack did not match advertised pack", "UUID", pack.UUID, "version", pack.Version, "cached_UUID", cachedPack.UUID(), "cached_version", cachedPack.Version(), "cached_size", cachedPack.Len())
+			case cachedPack != nil:
+				conn.resourcePacks = append(conn.resourcePacks, cachedPack.WithContentKey(pack.ContentKey))
+				conn.packQueue.packAmount--
+				continue
+			}
+		}
+
 		// This UUID_Version is a hack Mojang put in place.
 		packsToDownload = append(packsToDownload, id+"_"+pack.Version)
 		conn.packQueue.downloadingPacks[id] = downloadingPack{
@@ -990,6 +1016,7 @@ func (conn *Conn) handleResourcePacksInfo(pk *packet.ResourcePacksInfo) error {
 			buf:        bytes.NewBuffer(make([]byte, 0, pack.Size)),
 			newFrag:    make(chan []byte),
 			contentKey: pack.ContentKey,
+			cacheKey:   cacheKey,
 		}
 	}
 
@@ -1005,6 +1032,17 @@ func (conn *Conn) handleResourcePacksInfo(pk *packet.ResourcePacksInfo) error {
 
 	_ = conn.WritePacket(&packet.ResourcePackClientResponse{Response: packet.PackResponseAllPacksDownloaded})
 	return nil
+}
+
+// storeResourcePack stores a downloaded pack in the Conn's ResourcePackCache, if any.
+func (conn *Conn) storeResourcePack(key ResourcePackCacheKey, pack *resource.Pack) {
+	if conn.resourcePackCache == nil || !key.Matches(pack) {
+		// A pack that does not match its own key would never be returned as a hit on a later login.
+		return
+	}
+	if err := conn.resourcePackCache.Store(conn.ctx, key, pack); err != nil {
+		conn.log.Warn("failed to store resource pack in cache", "UUID", pack.UUID(), "version", pack.Version(), "err", err)
+	}
 }
 
 // handleResourcePackStack handles a ResourcePackStack packet sent by the server. The stack defines the order
@@ -1048,15 +1086,6 @@ func (conn *Conn) hasPack(uuid string, version string, hasBehaviours bool) bool 
 	return false
 }
 
-const (
-	// packChunkSize is the size of a single chunk of data from a resource pack: 128 KiB.
-	packChunkSize = 1024 * 128
-	// resourcePackChunkSendDelay spaces ResourcePackChunkData packets so slow clients are not flooded while
-	// downloading packs. Clients after 1.26.30 may fail resource pack downloads when pack chunks are sent
-	// too aggressively.
-	resourcePackChunkSendDelay = 200 * time.Millisecond
-)
-
 // handleResourcePackClientResponse handles an incoming resource pack client response packet. The packet is
 // handled differently depending on the response.
 func (conn *Conn) handleResourcePackClientResponse(pk *packet.ResourcePackClientResponse) error {
@@ -1067,7 +1096,10 @@ func (conn *Conn) handleResourcePackClientResponse(pk *packet.ResourcePackClient
 		return conn.close(conn.closeErr("resource pack refused"))
 	case packet.PackResponseSendPacks:
 		packs := pk.PacksToDownload
-		conn.packQueue = &resourcePackQueue{packs: conn.resourcePacks}
+		conn.packQueue = &resourcePackQueue{
+			packs:     conn.resourcePacks,
+			chunkSize: conn.resourcePackDelivery.ChunkSize,
+		}
 		if err := conn.packQueue.Request(packs); err != nil {
 			return fmt.Errorf("lookup resource packs by UUID: %w", err)
 		}
@@ -1224,25 +1256,30 @@ func (conn *Conn) handleResourcePackDataInfo(pk *packet.ResourcePackDataInfo) er
 			}
 		}
 		conn.packMu.Lock()
-		defer conn.packMu.Unlock()
-
 		if pack.buf.Len() != int(pack.size) {
 			conn.log.Error(fmt.Sprintf("download resource pack: incorrect resource pack size: expected %v, got %v", pack.size, pack.buf.Len()), "UUID", id)
+			conn.packMu.Unlock()
 			return
 		}
 		// First parse the resource pack from the total byte buffer we obtained.
 		newPack, err := resource.Read(pack.buf)
 		if err != nil {
 			conn.log.Error("download resource pack: invalid full resource pack data: "+err.Error(), "UUID", id)
+			conn.packMu.Unlock()
 			return
 		}
+		newPack = newPack.WithContentKey(pack.contentKey)
 		conn.packQueue.packAmount--
 		// Finally we add the resource to the resource packs slice.
-		conn.resourcePacks = append(conn.resourcePacks, newPack.WithContentKey(pack.contentKey))
-		if conn.packQueue.packAmount == 0 {
+		conn.resourcePacks = append(conn.resourcePacks, newPack)
+		packAmount := conn.packQueue.packAmount
+		conn.packMu.Unlock()
+
+		if packAmount == 0 {
 			conn.expect(packet.IDResourcePackStack)
 			_ = conn.WritePacket(&packet.ResourcePackClientResponse{Response: packet.PackResponseAllPacksDownloaded})
 		}
+		conn.storeResourcePack(pack.cacheKey, newPack)
 	}()
 	return nil
 }
@@ -1275,20 +1312,21 @@ func (conn *Conn) handleResourcePackChunkData(pk *packet.ResourcePackChunkData) 
 // pack to be downloaded.
 func (conn *Conn) handleResourcePackChunkRequest(pk *packet.ResourcePackChunkRequest) error {
 	current := conn.packQueue.currentPack
+	chunkSize := uint64(conn.packQueue.chunkSize)
 	uuid, _, _ := strings.Cut(pk.UUID, "_")
 	if current.UUID().String() != uuid {
 		return fmt.Errorf("expected pack UUID %v, but got %v", current.UUID(), pk.UUID)
 	}
-	if conn.packQueue.currentOffset != uint64(pk.ChunkIndex)*packChunkSize {
-		return fmt.Errorf("expected pack UUID %v, but got %v", conn.packQueue.currentOffset/packChunkSize, pk.ChunkIndex)
+	if conn.packQueue.currentOffset != uint64(pk.ChunkIndex)*chunkSize {
+		return fmt.Errorf("expected chunk index %v, but got %v", conn.packQueue.currentOffset/chunkSize, pk.ChunkIndex)
 	}
 	response := &packet.ResourcePackChunkData{
 		UUID:       pk.UUID,
 		ChunkIndex: uint32(pk.ChunkIndex),
 		DataOffset: conn.packQueue.currentOffset,
-		Data:       make([]byte, packChunkSize),
+		Data:       make([]byte, chunkSize),
 	}
-	conn.packQueue.currentOffset += packChunkSize
+	conn.packQueue.currentOffset += chunkSize
 	// We read the data directly into the response's data.
 	if n, err := current.ReadAt(response.Data, int64(response.DataOffset)); err != nil {
 		// If we hit an EOF, we don't need to return an error, as we've simply reached the end of the content
@@ -1310,7 +1348,7 @@ func (conn *Conn) handleResourcePackChunkRequest(pk *packet.ResourcePackChunkReq
 			conn.expect(packet.IDResourcePackClientResponse)
 		}
 	}
-	if err := waitResourcePackChunkSendDelay(conn.ctx); err != nil {
+	if err := waitResourcePackChunkSendDelay(conn.ctx, conn.resourcePackDelivery.ChunkSendDelay); err != nil {
 		return err
 	}
 
@@ -1318,8 +1356,11 @@ func (conn *Conn) handleResourcePackChunkRequest(pk *packet.ResourcePackChunkReq
 }
 
 // waitResourcePackChunkSendDelay waits before processing the next resource pack chunk request.
-func waitResourcePackChunkSendDelay(ctx context.Context) error {
-	timer := time.NewTimer(resourcePackChunkSendDelay)
+func waitResourcePackChunkSendDelay(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
 	defer timer.Stop()
 
 	select {

--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -215,7 +215,10 @@ func newConn(netConn net.Conn, key *ecdsa.PrivateKey, log *slog.Logger, proto Pr
 		proto:        proto,
 		readerLimits: limits,
 
-		resourcePackDelivery: ResourcePackDeliveryConfig{}.normalized(),
+		resourcePackDelivery: ResourcePackDeliveryConfig{
+			ChunkSize:      DefaultResourcePackChunkSize,
+			ChunkSendDelay: DefaultResourcePackChunkSendDelay,
+		},
 	}
 	if d, ok := netConn.(packet.EncryptionDisabler); ok {
 		conn.disableEncryption = d.DisableEncryption()

--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -215,10 +215,7 @@ func newConn(netConn net.Conn, key *ecdsa.PrivateKey, log *slog.Logger, proto Pr
 		proto:        proto,
 		readerLimits: limits,
 
-		resourcePackDelivery: ResourcePackDeliveryConfig{
-			ChunkSize:      DefaultResourcePackChunkSize,
-			ChunkSendDelay: DefaultResourcePackChunkSendDelay,
-		},
+		resourcePackDelivery: defaultResourcePackDeliveryConfig(),
 	}
 	if d, ok := netConn.(packet.EncryptionDisabler); ok {
 		conn.disableEncryption = d.DisableEncryption()

--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -76,6 +76,9 @@ type Dialer struct {
 	// and version of the resource pack, the number of the current pack being downloaded, and the total amount of packs.
 	// The boolean returned determines if the pack will be downloaded or not.
 	DownloadResourcePack func(id uuid.UUID, version string, current, total int) bool
+	// ResourcePackCache, if set, reuses resource packs downloaded on earlier logins. Misses and errors
+	// fall back to a normal download.
+	ResourcePackCache ResourcePackCache
 
 	// DisconnectOnUnknownPackets specifies if the connection should disconnect if packets received are not present
 	// in the packet pool. If true, such packets lead to the connection being closed immediately.
@@ -249,6 +252,7 @@ func (d Dialer) DialContextNetwork(ctx context.Context, network Network, address
 	conn.clientData = d.ClientData
 	conn.packetFunc = d.PacketFunc
 	conn.downloadResourcePack = d.DownloadResourcePack
+	conn.resourcePackCache = d.ResourcePackCache
 	conn.cacheEnabled = d.EnableClientCache
 	conn.disconnectOnInvalidPacket = d.DisconnectOnInvalidPackets
 	conn.disconnectOnUnknownPacket = d.DisconnectOnUnknownPackets

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -103,6 +103,9 @@ type ListenConfig struct {
 	// If set, it will be called before sending the ResourcePacksInfo packet. The returned resource packs
 	// will be forwarded to the client in place of the Listener's current ones.
 	FetchResourcePacks func(identityData login.IdentityData, clientData login.ClientData, current []*resource.Pack) []*resource.Pack
+	// ResourcePackDelivery controls how resource pack data is sent to clients. The zero value keeps the
+	// conservative default chunk size and pacing.
+	ResourcePackDelivery ResourcePackDeliveryConfig
 
 	// PacketFunc is called whenever a packet is read from or written to a connection returned when using
 	// Listener.Accept. It includes packets that are otherwise covered in the connection sequence, such as the
@@ -429,6 +432,7 @@ func (listener *Listener) createConn(netConn net.Conn) {
 	conn.forceDisableVibrantVisuals = listener.cfg.ForceDisableVibrantVisuals
 	conn.resourcePacks = packs
 	conn.fetchResourcePacks = listener.cfg.FetchResourcePacks
+	conn.resourcePackDelivery = listener.cfg.ResourcePackDelivery.normalized()
 	conn.gameData.WorldName = listener.status().ServerName
 	conn.authEnabled = !listener.cfg.AuthenticationDisabled
 	conn.verifier = listener.verifier

--- a/minecraft/resource_pack_cache.go
+++ b/minecraft/resource_pack_cache.go
@@ -1,0 +1,79 @@
+package minecraft
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/sandertv/gophertunnel/minecraft/resource"
+)
+
+// ResourcePackCacheKey identifies a resource pack advertised in the ResourcePacksInfo packet. Like the
+// vanilla client's own pack cache, pack content is assumed not to change without a version bump; the
+// advertised size is included as an extra guard.
+type ResourcePackCacheKey struct {
+	UUID    uuid.UUID
+	Version string
+	Size    uint64
+}
+
+// Matches reports whether pack has the UUID, version and size the key holds.
+func (key ResourcePackCacheKey) Matches(pack *resource.Pack) bool {
+	return pack.UUID() == key.UUID && pack.Version() == key.Version && uint64(pack.Len()) == key.Size
+}
+
+// ResourcePackCache allows a Dialer to reuse resource packs downloaded earlier. Cache failures are
+// non-fatal: a nil pack or an error from Load falls back to a normal download, and errors from Store are
+// only logged.
+type ResourcePackCache interface {
+	// Load returns the pack stored under key, or nil if it is not cached.
+	Load(ctx context.Context, key ResourcePackCacheKey) (*resource.Pack, error)
+	// Store stores a pack under key for a later Load.
+	Store(ctx context.Context, key ResourcePackCacheKey, pack *resource.Pack) error
+}
+
+// DirResourcePackCache is a ResourcePackCache that stores resource packs as files in a directory. Entries
+// are never evicted: the caller owns the directory and its lifecycle.
+type DirResourcePackCache struct {
+	// Dir is the directory packs are stored in. It is created when the first pack is stored.
+	Dir string
+}
+
+// Load returns the pack stored under key, or nil if no file exists for it.
+func (cache DirResourcePackCache) Load(_ context.Context, key ResourcePackCacheKey) (*resource.Pack, error) {
+	pack, err := resource.ReadPath(cache.path(key))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	return pack, err
+}
+
+// Store writes the pack to a file under key, replacing any previous entry.
+func (cache DirResourcePackCache) Store(_ context.Context, key ResourcePackCacheKey, pack *resource.Pack) error {
+	if err := os.MkdirAll(cache.Dir, 0o755); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(cache.Dir, "pack-*.tmp")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(temp.Name()) }()
+	if _, err := io.Copy(temp, io.NewSectionReader(pack, 0, int64(pack.Len()))); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temp.Name(), cache.path(key))
+}
+
+// path returns the file a pack with key is stored at. The version is escaped as it comes from the server.
+func (cache DirResourcePackCache) path(key ResourcePackCacheKey) string {
+	return filepath.Join(cache.Dir, key.UUID.String()+"_"+url.PathEscape(key.Version)+".mcpack")
+}

--- a/minecraft/resource_pack_delivery.go
+++ b/minecraft/resource_pack_delivery.go
@@ -22,13 +22,22 @@ type ResourcePackDeliveryConfig struct {
 	ChunkSendDelay time.Duration
 }
 
+// defaultResourcePackDeliveryConfig returns the default resource pack delivery configuration.
+func defaultResourcePackDeliveryConfig() ResourcePackDeliveryConfig {
+	return ResourcePackDeliveryConfig{
+		ChunkSize:      DefaultResourcePackChunkSize,
+		ChunkSendDelay: DefaultResourcePackChunkSendDelay,
+	}
+}
+
 // normalized returns the configuration with defaults filled in.
 func (config ResourcePackDeliveryConfig) normalized() ResourcePackDeliveryConfig {
+	defaults := defaultResourcePackDeliveryConfig()
 	if config.ChunkSize == 0 {
-		config.ChunkSize = DefaultResourcePackChunkSize
+		config.ChunkSize = defaults.ChunkSize
 	}
 	if config.ChunkSendDelay == 0 {
-		config.ChunkSendDelay = DefaultResourcePackChunkSendDelay
+		config.ChunkSendDelay = defaults.ChunkSendDelay
 	} else if config.ChunkSendDelay < 0 {
 		config.ChunkSendDelay = 0
 	}

--- a/minecraft/resource_pack_delivery.go
+++ b/minecraft/resource_pack_delivery.go
@@ -1,0 +1,36 @@
+package minecraft
+
+import "time"
+
+const (
+	// DefaultResourcePackChunkSize is the size of a single chunk of data from a resource pack sent by a
+	// Listener: 128 KiB.
+	DefaultResourcePackChunkSize = 1024 * 128
+	// DefaultResourcePackChunkSendDelay is the delay a Listener leaves between ResourcePackChunkData
+	// packets, so slow clients are not flooded while downloading packs. Clients after 1.26.30 may fail
+	// resource pack downloads when pack chunks are sent too aggressively.
+	DefaultResourcePackChunkSendDelay = 200 * time.Millisecond
+)
+
+// ResourcePackDeliveryConfig controls how a Listener sends resource pack data to clients. The zero value
+// keeps the conservative defaults.
+type ResourcePackDeliveryConfig struct {
+	// ChunkSize is the size of each ResourcePackChunkData payload. Zero uses DefaultResourcePackChunkSize.
+	ChunkSize uint32
+	// ChunkSendDelay is the delay after each ResourcePackChunkData packet. Zero uses
+	// DefaultResourcePackChunkSendDelay; a negative delay disables pacing.
+	ChunkSendDelay time.Duration
+}
+
+// normalized returns the configuration with defaults filled in.
+func (config ResourcePackDeliveryConfig) normalized() ResourcePackDeliveryConfig {
+	if config.ChunkSize == 0 {
+		config.ChunkSize = DefaultResourcePackChunkSize
+	}
+	if config.ChunkSendDelay == 0 {
+		config.ChunkSendDelay = DefaultResourcePackChunkSendDelay
+	} else if config.ChunkSendDelay < 0 {
+		config.ChunkSendDelay = 0
+	}
+	return config
+}

--- a/minecraft/resource_pack_queue.go
+++ b/minecraft/resource_pack_queue.go
@@ -20,6 +20,7 @@ type resourcePackQueue struct {
 	packAmount       int
 	downloadingPacks map[string]downloadingPack
 	awaitingPacks    map[string]*downloadingPack
+	chunkSize        uint32
 }
 
 // downloadingPack is a resource pack that is being downloaded by a client connection.
@@ -30,6 +31,7 @@ type downloadingPack struct {
 	expectedIndex uint32
 	newFrag       chan []byte
 	contentKey    string
+	cacheKey      ResourcePackCacheKey
 }
 
 // Request 'requests' all resource packs passed, provided they all exist in the resourcePackQueue. Clients
@@ -79,8 +81,8 @@ func (queue *resourcePackQueue) NextPack() (pk *packet.ResourcePackDataInfo, ok 
 		}
 		return &packet.ResourcePackDataInfo{
 			UUID:          pack.UUID().String() + "_" + pack.Version(),
-			DataChunkSize: packChunkSize,
-			ChunkCount:    uint32(pack.DataChunkCount(packChunkSize)),
+			DataChunkSize: queue.chunkSize,
+			ChunkCount:    uint32(pack.DataChunkCount(int(queue.chunkSize))),
 			Size:          uint64(pack.Len()),
 			Hash:          checksum[:],
 			PackType:      packType,


### PR DESCRIPTION
## Summary

- Adds an optional `ResourcePackCache` to `minecraft.Dialer`. Clients that reconnect to the same server frequently — proxies, bots and other non-vanilla clients — currently re-download every resource pack on every login. With a cache set, packs downloaded once are reused on later logins; a miss or cache error just falls back to the normal download. `DirResourcePackCache` is included as a stock disk-backed implementation storing `<uuid>_<version>.mcpack` files with an atomic temp+rename store.
- Adds a `ResourcePackDeliveryConfig` to `minecraft.ListenConfig` so a server can tune how pack data is sent: chunk size and the delay between `ResourcePackChunkData` packets. This allows non-vanilla bots and clients (for example our downstream client, Cinnabar) to download packs much faster over a trusted or local connection, while the zero value keeps the existing conservative defaults (128 KiB chunks spaced 200 ms apart, as introduced in #446) for vanilla clients.

## Design notes

- Packs are keyed by the advertised UUID, version and size (`ResourcePackCacheKey`). Like the vanilla client's own pack cache, content is assumed not to change without a version bump; the size acts as an extra guard, checked via `key.Matches` both when loading and before storing.
- The cache is consulted in `handleResourcePacksInfo` before packs are requested, so cached packs are excluded from `PacksToDownload` entirely.
- `AllPacksDownloaded` is sent before the last pack is stored in the cache, so a slow store cannot delay login.
- In `ResourcePackDeliveryConfig`, zero values mean defaults for both fields; a negative `ChunkSendDelay` disables pacing explicitly. This keeps a partially filled config safe: setting only `ChunkSize` does not silently drop the send delay.

## Validation

`go build ./...`, `go vet ./minecraft/...` and `go test ./minecraft ./minecraft/resource` all pass. Also validated with a local round-trip test: download → store → second login served from the cache with no network request, and a mismatching cached pack falling back to a normal download.