### PR TITLE
minecraft: flush resource pack chunks before pacing

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -1301,6 +1301,9 @@ func (conn *Conn) handleResourcePackChunkRequest(pk *packet.ResourcePackChunkReq
 	if err := conn.WritePacket(response); err != nil {
 		return fmt.Errorf("send ResourcePackChunkData: %w", err)
 	}
+	if err := conn.Flush(); err != nil {
+		return fmt.Errorf("flush ResourcePackChunkData: %w", err)
+	}
 
 	lastChunk := response.DataOffset+uint64(len(response.Data)) >= uint64(current.Len())
 	if lastChunk {


### PR DESCRIPTION
## Summary

- Flush each `ResourcePackChunkData` packet before applying the compatibility pacing delay.
- Keep the final chunk separate from the next pack's `ResourcePackDataInfo` packet.
- Add a regression test proving the chunk reaches the transport before the delay expires.

## Why

The 1.26.30+ client resource-pack downloader uses an asynchronous chunk queue and can stall when delivery is buffered or batched too aggressively. The existing 200 ms pacing was applied before the outer packet handler flushed its buffer, so a chunk could remain queued during the pacing window.