### PR TITLE
minecraft/nbt: fix unsafe string encoding

### DIFF
--- a/minecraft/nbt/encoding.go
+++ b/minecraft/nbt/encoding.go
@@ -107,7 +107,7 @@ func (networkLittleEndian) WriteString(w *offsetWriter, x string) error {
 		return FailedWriteError{Op: "WriteString", Off: w.off}
 	}
 	// Use unsafe conversion from a string to a byte slice to prevent copying.
-	if _, err := w.Write(*(*[]byte)(unsafe.Pointer(&x))); err != nil {
+	if _, err := w.Write(unsafe.Slice(unsafe.StringData(x), len(x))); err != nil {
 		return FailedWriteError{Op: "WriteString", Off: w.off}
 	}
 	return nil

--- a/minecraft/nbt/encoding_big_endian.go
+++ b/minecraft/nbt/encoding_big_endian.go
@@ -69,7 +69,7 @@ func (e bigEndian) WriteString(w *offsetWriter, x string) error {
 		return FailedWriteError{Op: "WriteString", Off: w.off}
 	}
 	// Use unsafe conversion from a string to a byte slice to prevent copying.
-	b := *(*[]byte)(unsafe.Pointer(&x))
+	b := unsafe.Slice(unsafe.StringData(x), len(x))
 	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteString", Off: w.off}
 	}
@@ -227,7 +227,7 @@ func (e littleEndian) WriteString(w *offsetWriter, x string) error {
 		return FailedWriteError{Op: "WriteString", Off: w.off}
 	}
 	// Use unsafe conversion from a string to a byte slice to prevent copying.
-	b := *(*[]byte)(unsafe.Pointer(&x))
+	b := unsafe.Slice(unsafe.StringData(x), len(x))
 	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteString", Off: w.off}
 	}

--- a/minecraft/nbt/encoding_little_endian.go
+++ b/minecraft/nbt/encoding_little_endian.go
@@ -69,7 +69,7 @@ func (e littleEndian) WriteString(w *offsetWriter, x string) error {
 		return FailedWriteError{Op: "WriteString", Off: w.off}
 	}
 	// Use unsafe conversion from a string to a byte slice to prevent copying.
-	b := *(*[]byte)(unsafe.Pointer(&x))
+	b := unsafe.Slice(unsafe.StringData(x), len(x))
 	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteString", Off: w.off}
 	}
@@ -227,7 +227,7 @@ func (e bigEndian) WriteString(w *offsetWriter, x string) error {
 		return FailedWriteError{Op: "WriteString", Off: w.off}
 	}
 	// Use unsafe conversion from a string to a byte slice to prevent copying.
-	b := *(*[]byte)(unsafe.Pointer(&x))
+	b := unsafe.Slice(unsafe.StringData(x), len(x))
 	if _, err := w.Write(b); err != nil {
 		return FailedWriteError{Op: "WriteString", Off: w.off}
 	}


### PR DESCRIPTION
## Summary

- Replace invalid string-header-to-slice-header conversions in all NBT string encoders.
- Use `unsafe.StringData` and `unsafe.Slice` to construct a zero-copy byte view with the correct length and capacity.
- Apply the same fix to network little-endian, native little-endian, and native big-endian implementations.

## Root cause

A Go string header contains a data pointer and length, while a slice header also contains a capacity. Reinterpreting `&x` directly as `*[]byte` reads an unrelated third word as the slice capacity. This can produce an invalid slice and panic when the NBT encoder writes a string.

The replacement still avoids copying, but constructs the slice explicitly from the string data pointer and length.