### PR TITLE
protocol: correct command argument type constants

### DIFF
--- a/minecraft/protocol/command.go
+++ b/minecraft/protocol/command.go
@@ -76,9 +76,9 @@ const (
 
 const (
 	CommandArgTypeInt = iota + 1
+	_
 	CommandArgTypeFloat
 	CommandArgTypeValue
-	CommandArgTypeRValue
 	CommandArgTypeWildcardInt
 	CommandArgTypeOperator
 	CommandArgTypeCompareOperator


### PR DESCRIPTION
The 1.26.33 client uses packet argument type ID `3` for float and ID `4` for value. ID `2` is unused.

This updates the constants accordingly:

- Keeps `CommandArgTypeInt` at `1`
- Reserves ID `2`
- Moves `CommandArgTypeFloat` to `3`
- Keeps `CommandArgTypeValue` at `4`
- Removes `CommandArgTypeRValue`, which is not a packet-facing argument type

This fixes float arguments being displayed as `unknown` without removing the valid `CommandArgTypeValue` constant.