### PR TITLE
protocol/packet: encode HurtArmour ArmourSlots as an unsigned varint

### DIFF
--- a/minecraft/protocol/packet/hurt_armour.go
+++ b/minecraft/protocol/packet/hurt_armour.go
@@ -15,7 +15,7 @@ type HurtArmour struct {
 	// thorns that the armour may have.
 	Damage int32
 	// ArmourSlots is a bitset of all armour slots affected.
-	ArmourSlots int64
+	ArmourSlots uint64
 }
 
 // ID ...
@@ -26,5 +26,5 @@ func (*HurtArmour) ID() uint32 {
 func (pk *HurtArmour) Marshal(io protocol.IO) {
 	io.Varint32(&pk.Cause)
 	io.Varint32(&pk.Damage)
-	io.Varint64(&pk.ArmourSlots)
+	io.Varuint64(&pk.ArmourSlots)
 }


### PR DESCRIPTION
`HurtArmour.ArmourSlots` is documented as *"a bitset of all armour slots affected"* but is written with `Varint64`, which zigzag-encodes. A bitset has no negative values, so zigzagging shifts every bit left by one — the encoded value no longer matches the slots the client is meant to read for any non-zero bitset.

Three independent sources encode it unsigned:

- **CloudburstMC/Protocol** writes it with `VarInts.writeUnsignedLong`.
- **[endstonemc/protocol-docs](https://github.com/endstonemc/protocol-docs)**, extracted from a running BDS by `protocol-dumper`, types `Armor Slots` as `uvarint64`.
- **Mojang's published protocol documentation** marks the field unsigned with compression.

I found this while building a wire-conformance check that compares generated Bedrock protocol code against gophertunnel packet by packet — this was the only field where all three of those sources disagreed with gophertunnel in the same direction, which is what made it stand out rather than look like a documentation error.

The field is changed to `uint64` alongside the encoding, since a bitset is naturally unsigned and leaving it `int64` would just move the sign confusion to callers.

No tests included, as requested by the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)