### PR TITLE
protocol: encode PrimitiveShape.AttachedToEntityID as an ActorUniqueID

### DIFF
--- a/minecraft/protocol/shape.go
+++ b/minecraft/protocol/shape.go
@@ -262,8 +262,9 @@ type PrimitiveShape struct {
 	NetworkID uint64
 	// DimensionID is the optional dimension ID where the shape is rendered.
 	DimensionID Optional[int32]
-	// AttachedToEntityID is the optional runtime ID of the entity the shape is attached to.
-	AttachedToEntityID Optional[uint64]
+	// AttachedToEntityID is the optional unique ID of the entity the shape is attached to. Mojang's documentation
+	// describes it as a runtime ID, but the field is an ActorUniqueID and the client resolves it as one.
+	AttachedToEntityID Optional[int64]
 	// Type is the type of the shape.
 	// If not set, the set shape will be cleared.
 	Type Optional[uint8]
@@ -294,6 +295,6 @@ func (x *PrimitiveShape) Marshal(io IO) {
 	OptionalFunc(io, &x.MaxRenderDistance, io.Float32)
 	OptionalFunc(io, &x.Colour, io.BEARGB)
 	OptionalFunc(io, &x.DimensionID, io.Varint32)
-	OptionalFunc(io, &x.AttachedToEntityID, io.ActorRuntimeID)
+	OptionalFunc(io, &x.AttachedToEntityID, io.ActorUniqueID)
 	io.ShapeData(&x.ExtraShapeData)
 }


### PR DESCRIPTION
`PrimitiveShape.AttachedToEntityID` is an `ActorUniqueID`: a signed, zigzag encoded varint carrying a **unique** ID. It was typed `uint64` and marshalled with `io.ActorRuntimeID`, which writes an unsigned varint, so it was wrong on both counts — the client read the zigzag form of a value that was the wrong kind of ID to begin with, resolved no entity, and dropped the shape without rendering it or reporting anything.

Mojang's own documentation is the reason this is easy to get wrong. In [`json/PrimitiveShapeDataPayload.json`](https://github.com/Mojang/bedrock-protocol-docs/blob/7330880ab78ef001cad0b9cdfedb3aa3eaa6d4af/json/PrimitiveShapeDataPayload.json#L10-L12) the field is documented as a runtime ID while being typed as an `ActorUniqueID`:

```json
"Attached To Entity ID": {
    "description": "Runtime ID of the entity this shape is attached to.",
    "$ref": "./ActorUniqueID.json",
```

The `$ref` is correct and the description is not. [`ActorUniqueID.json`](https://github.com/Mojang/bedrock-protocol-docs/blob/7330880ab78ef001cad0b9cdfedb3aa3eaa6d4af/json/ActorUniqueID.json) resolves to an `int64` with `"x-serialization-options": ["Compression"]`, and the BDS-extracted type has been `ActorUniqueID` in every release since the field appeared in `r26_u2`.

This survives testing because most server software issues a single counter for both IDs — dragonfly included, where `EntityUniqueID` is written as `int64(runtimeID)` — so a runtime ID lands on the right entity anyway. Vanilla BDS assigns the two independently, and there every attached shape silently fails to render. Verified against a vanilla BDS instance: attaching by unique ID renders, attaching by runtime ID does not.

Note that this changes the field's type, so callers passing a runtime ID need to pass the entity's unique ID instead.
