### PR TITLE
protocol: Fix PresenceInfo wire format

### DIFF
--- a/minecraft/protocol/server_join_information.go
+++ b/minecraft/protocol/server_join_information.go
@@ -50,20 +50,14 @@ func (x *StoreEntryPointInfo) Marshal(r IO) {
 
 // PresenceInfo contains presence information about the experience.
 type PresenceInfo struct {
-	// ExperienceName is the optional name of the experience.
-	ExperienceName Optional[string]
-	// WorldName is the optional name of the world.
-	WorldName Optional[string]
 	// RichPresenceID is the rich presence ID overriding the client-driven
 	// rich presence.
-	RichPresenceID string
+	RichPresenceID Optional[string]
 }
 
 // Marshal encodes/decodes a PresenceInfo.
 func (x *PresenceInfo) Marshal(r IO) {
-	OptionalFunc(r, &x.ExperienceName, r.String)
-	OptionalFunc(r, &x.WorldName, r.String)
-	r.String(&x.RichPresenceID)
+	OptionalFunc(r, &x.RichPresenceID, r.String)
 }
 
 // ServerJoinInformation contains optional information about the server the player is joining.


### PR DESCRIPTION
## Summary

Update `PresenceInfo` to match the current Bedrock wire format: one optional rich-presence ID.

The existing definition reads two obsolete optional name fields followed by an unconditional string. When a server sends default presence information in `StartGame`, that layout consumes the following `ServerID` field and shifts the remaining packet payload.

## Evidence

- The 1.26.40 BDS-derived schema defines `PresenceConfiguration` as only an optional `richPresenceId` string.
- A live Dimension Clash `StartGame` capture had presence information set with no rich-presence override. The old decoder failed with `string length 99 exceeds remaining packet payload 32`; this change decoded the full payload with zero trailing bytes.

## Validation

- `go test ./... -count=1`
- `git diff --check`