### PR TITLE
Fix player list action constants for Bedrock 1.26.40

### DIFF
--- a/minecraft/protocol/player.go
+++ b/minecraft/protocol/player.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	PlayerListActionAdd = iota
-	PlayerListActionRemove
+	PlayerListActionRemove = iota
+	PlayerListActionAdd
 )
 
 const (


### PR DESCRIPTION
The PlayerList action constants were ordered incorrectly.

Bedrock protocol defines:
- PlayerListActionRemove = 0
- PlayerListActionAdd = 1

The previous implementation had PlayerListActionAdd = 0 and PlayerListActionRemove = 1 due to iota ordering, causing player list packets to be interpreted incorrectly by newer clients such as 1.26.40.

This changes the constants to match the protocol values.