### PR TITLE
minecraft: advertise extended server-list metadata

### DIFF
--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -372,14 +372,9 @@ func (listener *Listener) updatePongData() {
 	}); ok {
 		port = a.AddrPort().Port()
 	}
-	authOnline, authOffline := "0", "1"
-	if !listener.cfg.AuthenticationDisabled {
-		authOnline, authOffline = "1", "0"
-	}
-	listener.listener.PongData([]byte(fmt.Sprintf("MCPE;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;",
+	listener.listener.PongData([]byte(fmt.Sprintf("MCPE;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;",
 		s.ServerName, protocol.CurrentProtocol, protocol.CurrentVersion, s.PlayerCount, s.MaxPlayers,
-		listener.listener.ID(), s.ServerSubName, "Creative", 1, "1", port, port, "0", authOnline,
-		authOffline,
+		listener.listener.ID(), s.ServerSubName, "Creative", 1, port, port, 0, 0,
 	)))
 }
 

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -372,9 +372,14 @@ func (listener *Listener) updatePongData() {
 	}); ok {
 		port = a.AddrPort().Port()
 	}
-	listener.listener.PongData([]byte(fmt.Sprintf("MCPE;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;",
+	authOnline, authOffline := "0", "1"
+	if !listener.cfg.AuthenticationDisabled {
+		authOnline, authOffline = "1", "0"
+	}
+	listener.listener.PongData([]byte(fmt.Sprintf("MCPE;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;",
 		s.ServerName, protocol.CurrentProtocol, protocol.CurrentVersion, s.PlayerCount, s.MaxPlayers,
-		listener.listener.ID(), s.ServerSubName, "Creative", 1, port, port, 0,
+		listener.listener.ID(), s.ServerSubName, "Creative", 1, "1", port, port, "0", authOnline,
+		authOffline,
 	)))
 }
 


### PR DESCRIPTION
## Summary

- append the Bedrock 1.26.40 hardcore flag after the existing editor-world field
- preserve the existing game-mode/joinability field and IPv4/IPv6 port positions

## Evidence

- Endstone's exact BDS 1.26.40 server-list hook preserves two fields after the ports: editor world and hardcore: https://github.com/EndstoneMC/endstone/commit/35e3c33a248065ac8a760e94b4153c179b8a72a3
- Cloudburst's current BedrockPong model keeps the IPv4 and IPv6 ports in fields 10 and 11: https://github.com/CloudburstMC/Protocol/blob/8c215aade77457529153278e68954dda6403e9c6/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockPong.java

## Validation

- temporary regression test reproduced the shifted 17-field pong, then passed with the exact 14-field layout; removed before staging
- `go test ./minecraft ./minecraft/protocol ./minecraft/protocol/packet -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`

No test files changed.
