### PR TITLE
minecraft: apply a default inbound decompression limit to dialers

### DIFF
--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"math/rand"
 	"net"
 	"net/http"
@@ -109,6 +108,11 @@ type Dialer struct {
 	// to and read from the Conn are always any of those found in the protocol/packet package, as packets
 	// are converted from and to this Protocol.
 	Protocol Protocol
+
+	// MaxDecompressedLen is the maximum length of a decompressed packet batch to prevent potential exploits.
+	// If 0, the default value is 16MB (16 * 1024 * 1024). Setting this to a negative integer disables the
+	// limit.
+	MaxDecompressedLen int
 
 	// FlushRate is the rate at which packets sent are flushed. Packets are buffered for a duration up to
 	// FlushRate and are compressed/encrypted together to improve compression ratios. The lower this
@@ -298,7 +302,7 @@ func (d Dialer) DialContextNetwork(ctx context.Context, network Network, address
 	conn.cacheEnabled = d.EnableClientCache
 	conn.disconnectOnInvalidPacket = d.DisconnectOnInvalidPackets
 	conn.disconnectOnUnknownPacket = d.DisconnectOnUnknownPackets
-	conn.maxDecompressedLen = math.MaxInt
+	conn.maxDecompressedLen = d.MaxDecompressedLen
 
 	defaultIdentityData(&conn.identityData)
 	defaultClientData(address, conn.identityData.DisplayName, &conn.clientData)

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"net"
 	"net/http"
 	"net/netip"
@@ -113,7 +112,7 @@ type ListenConfig struct {
 	// from which the packet originated, and the destination address.
 	PacketFunc func(header packet.Header, payload []byte, src, dst net.Addr)
 
-	// MaxDecompressedLen is the maximum length of a decompressed packet to prevent potential exploits. If 0,
+	// MaxDecompressedLen is the maximum length of a decompressed packet batch to prevent potential exploits. If 0,
 	// the default value is 16MB (16 * 1024 * 1024). Setting this to a negative integer disables the limit.
 	MaxDecompressedLen int
 
@@ -192,11 +191,6 @@ func (cfg ListenConfig) ListenNetwork(network Network, address string) (*Listene
 		cfg.CompressionThreshold = 256
 	} else if cfg.CompressionThreshold < 0 {
 		cfg.CompressionThreshold = 0
-	}
-	if cfg.MaxDecompressedLen == 0 {
-		cfg.MaxDecompressedLen = 16 * 1024 * 1024 // 16MB
-	} else if cfg.MaxDecompressedLen < 0 {
-		cfg.MaxDecompressedLen = math.MaxInt
 	}
 
 	var verifier *oidc.IDTokenVerifier

--- a/minecraft/protocol/packet/decoder.go
+++ b/minecraft/protocol/packet/decoder.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 )
@@ -51,18 +52,20 @@ func NewDecoder(reader io.Reader) *Decoder {
 	}
 	if pr, ok := reader.(PacketReader); ok {
 		return &Decoder{
-			checkPacketLimit:  true,
-			pr:                pr,
-			header:            batch,
-			disableEncryption: disableEncryption,
+			checkPacketLimit:   true,
+			pr:                 pr,
+			header:             batch,
+			maxDecompressedLen: DefaultMaxDecompressedLen,
+			disableEncryption:  disableEncryption,
 		}
 	}
 	return &Decoder{
-		r:                 reader,
-		buf:               make([]byte, 1024*1024*3),
-		header:            batch,
-		checkPacketLimit:  true,
-		disableEncryption: disableEncryption,
+		r:                  reader,
+		buf:                make([]byte, 1024*1024*3),
+		header:             batch,
+		maxDecompressedLen: DefaultMaxDecompressedLen,
+		checkPacketLimit:   true,
+		disableEncryption:  disableEncryption,
 	}
 }
 
@@ -78,10 +81,16 @@ func (decoder *Decoder) EnableEncryption(keyBytes [32]byte) {
 	decoder.encrypt = newEncrypt(keyBytes[:], stream)
 }
 
-// EnableCompression enables compression for the Decoder.
+// EnableCompression enables compression for the Decoder. A maxDecompressedLen of 0 uses
+// DefaultMaxDecompressedLen; a negative value disables the limit.
 func (decoder *Decoder) EnableCompression(compression Compression, maxDecompressedLen int) {
 	decoder.decompress = true
 	decoder.compression = compression
+	if maxDecompressedLen == 0 {
+		maxDecompressedLen = DefaultMaxDecompressedLen
+	} else if maxDecompressedLen < 0 {
+		maxDecompressedLen = math.MaxInt
+	}
 	decoder.maxDecompressedLen = maxDecompressedLen
 }
 
@@ -97,6 +106,8 @@ const (
 	// maximumInBatch is the maximum amount of packets that may be found in a batch. If a compressed batch has
 	// more than this amount, decoding will fail.
 	maximumInBatch = 812
+	// DefaultMaxDecompressedLen is the default maximum decompressed batch size.
+	DefaultMaxDecompressedLen = 16 * 1024 * 1024
 )
 
 // Decode decodes one 'packet' from the io.Reader passed in NewDecoder(), producing a slice of packets that it
@@ -151,6 +162,11 @@ func (decoder *Decoder) Decode() (packets [][]byte, err error) {
 				return nil, fmt.Errorf("decompress batch: %w", err)
 			}
 		}
+	}
+
+	// Uncompressed batches skip Decompress, so the limit is enforced on the final payload too.
+	if len(data) > decoder.maxDecompressedLen {
+		return nil, fmt.Errorf("decode batch: size %v exceeds limit %v", len(data), decoder.maxDecompressedLen)
 	}
 
 	b := bytes.NewBuffer(data)


### PR DESCRIPTION
Listeners have `MaxDecompressedLen` (16 MiB default), but dialed connections pass `math.MaxInt`: a hostile or compromised server can OOM any gophertunnel client with a small zlib bomb. Since gophertunnel is widely used as a client library against untrusted servers, the dialer side is arguably where the limit matters most.

Changes:

- `Dialer` gains the same `MaxDecompressedLen` field as `ListenConfig`, with identical semantics: 0 means the 16 MiB default, negative disables the limit.
- The 0-means-default / negative-means-unlimited normalization moves from the listener into `Decoder.EnableCompression`, so every consumer shares it; `DefaultMaxDecompressedLen` is exported.
- The limit now also applies to batches sent with the uncompressed `0xff` marker, which previously bypassed `Decompress` and with it the limit entirely.

Behavior change: dialers that relied on unlimited decompressed batches (over 16 MiB after decompression) now need to set `MaxDecompressedLen: -1` or an explicit limit. Vanilla servers stay far below that in normal play.
