### PR TITLE
minecraft: update protocol to 1.26.44

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -861,7 +861,7 @@ func (conn *Conn) handleLogin(pk *packet.Login) error {
 
 		if conn.proto.Ver() == protocol.CurrentVersion {
 			_ = conn.WritePacket(&packet.PlayStatus{Status: packet.PlayStatusLoginFailedClient})
-			return fmt.Errorf("incompatible protocol game version: expected %v, got %v", protocol.CurrentVersion, conn.clientData.GameVersion)
+			return fmt.Errorf("incompatible protocol game version: expected %s, got %s", protocol.CurrentVersion, conn.clientData.GameVersion)
 		}
 	}
 

--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -861,7 +861,7 @@ func (conn *Conn) handleLogin(pk *packet.Login) error {
 
 		if conn.proto.Ver() == protocol.CurrentVersion {
 			_ = conn.WritePacket(&packet.PlayStatus{Status: packet.PlayStatusLoginFailedClient})
-			return conn.Close()
+			return fmt.Errorf("incompatible protocol game version: expected %v, got %v", protocol.CurrentVersion, conn.clientData.GameVersion)
 		}
 	}
 

--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -838,6 +838,33 @@ func (conn *Conn) handleLogin(pk *packet.Login) error {
 		return fmt.Errorf("parse login request: %w", err)
 	}
 
+	// TODO: Mojang bumped the protocol without changing the protocol version number in 1.26.44,
+	// so we need to check the game version to determine whether we need to downgrade the protocol.
+	// This is a temporary workaround until the protocol version is properly bumped in a future release.
+	var majorVer, minorVer, patchVer int
+	_, _ = fmt.Sscanf(conn.clientData.GameVersion, "%d.%d.%d", &majorVer, &minorVer, &patchVer)
+	if majorVer == 1 && minorVer == 26 && patchVer < 44 {
+		// Check if one of the accepted protocols matches the client's protocol version, such as
+		// 1.26.43, 1.26.42, 1.26.41, or 1.26.40. If a matching protocol is found, use it instead
+		// of the current protocol.
+		for _, pro := range conn.acceptedProto {
+			if pro.ID() == protocol.CurrentProtocol {
+				var majorVer, minorVer, patchVer int
+				_, _ = fmt.Sscanf(pro.Ver(), "%d.%d.%d", &majorVer, &minorVer, &patchVer)
+				if majorVer == 1 && minorVer == 26 && patchVer < 44 {
+					conn.proto = pro
+					conn.pool = pro.Packets(true)
+					break
+				}
+			}
+		}
+
+		if conn.proto.Ver() == protocol.CurrentVersion {
+			_ = conn.WritePacket(&packet.PlayStatus{Status: packet.PlayStatusLoginFailedClient})
+			return conn.Close()
+		}
+	}
+
 	// Make sure the player is logged in with XBOX Live when necessary.
 	if !authResult.XBOXLiveAuthenticated && conn.authEnabled {
 		_ = conn.WritePacket(&packet.Disconnect{Message: text.Colourf("<red>You must be logged in with XBOX Live to join.</red>")})

--- a/minecraft/protocol/info.go
+++ b/minecraft/protocol/info.go
@@ -4,5 +4,5 @@ const (
 	// CurrentProtocol is the current protocol version for the version below.
 	CurrentProtocol = 2168
 	// CurrentVersion is the current version of Minecraft as supported by the `packet` package.
-	CurrentVersion = "1.26.40"
+	CurrentVersion = "1.26.44"
 )

--- a/minecraft/protocol/scoreboard.go
+++ b/minecraft/protocol/scoreboard.go
@@ -55,7 +55,7 @@ func (x *ScoreboardEntry) Marshal(r IO) {
 		if x.ObjectiveName != "" {
 			objective = Option(x.ObjectiveName)
 		}
-		OptionalFunc(r, &objective, r.String)
+		DoubleOptionalFunc(r, &objective, r.String)
 		x.ObjectiveName, _ = objective.Value()
 	case ScoreboardIdentityEntity, ScoreboardIdentityPlayer:
 		r.String(&x.ObjectiveName)


### PR DESCRIPTION
* Added a temporary workaround in `conn.go` to detect clients running Minecraft 1.26.40–1.26.43 (since Mojang did not bump the protocol version for 1.26.44) by parsing the game version string and downgrading the protocol if necessary. This ensures clients on older patch versions can still connect correctly.
* Updated `CurrentVersion` in `protocol/info.go` from "1.26.40" to "1.26.44".
* Changed the serialization of `ScoreboardEntry.ObjectiveName` in `protocol/scoreboard.go` to use `DoubleOptionalFunc` instead of `OptionalFunc`, ensuring correct handling of optional fields for scoreboard identities.