### PR TITLE
minecraft/nethernet.go: Use the same domain as the vanilla client for identity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/coreos/go-oidc/v3 v3.17.0
-	github.com/df-mc/go-nethernet v1.0.20
+	github.com/df-mc/go-nethernet v1.0.20-0.20260818142457-6fc1eb6f907c
 	github.com/df-mc/go-playfab/v2 v2.0.2
 	github.com/df-mc/go-xsapi/v2 v2.0.3
 	github.com/df-mc/jsonc v1.0.5
@@ -13,6 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.18.1
 	github.com/pelletier/go-toml v1.9.5
+	github.com/pion/webrtc/v4 v4.2.16-0.20260627075746-7a223a6f4d4f
 	github.com/sandertv/go-raknet v1.15.2-0.20260705184311-0d1fd09e2cf6
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/net v0.50.0
@@ -21,6 +22,7 @@ require (
 )
 
 require (
+	github.com/andreburgaud/crypt2go v1.8.0 // indirect
 	github.com/coder/websocket v1.8.14 // indirect
 	github.com/pion/datachannel v1.6.2 // indirect
 	github.com/pion/dtls/v3 v3.1.4 // indirect
@@ -37,7 +39,6 @@ require (
 	github.com/pion/stun/v3 v3.1.6 // indirect
 	github.com/pion/transport/v4 v4.0.2 // indirect
 	github.com/pion/turn/v5 v5.0.10 // indirect
-	github.com/pion/webrtc/v4 v4.2.16-0.20260627075746-7a223a6f4d4f // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/image v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,15 @@
+github.com/andreburgaud/crypt2go v1.8.0 h1:J73vGTb1P6XL69SSuumbKs0DWn3ulbl9L92ZXBjw6pc=
+github.com/andreburgaud/crypt2go v1.8.0/go.mod h1:L5nfShQ91W78hOWhUH2tlGRPO+POAPJAF5fKOLB9SXg=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/df-mc/go-nethernet v1.0.20-0.20260815132320-af1dab3c85f4 h1:rBSzA0hDONgNeGdwnZEnng+TXG4PA1kaZ3lR9r4Q7Dw=
+github.com/df-mc/go-nethernet v1.0.20-0.20260815132320-af1dab3c85f4/go.mod h1:11MfQo5F7PDKfHg1H0zM5mMkrCv29jRE0lK5B4egW9w=
+github.com/df-mc/go-nethernet v1.0.20-0.20260818142457-6fc1eb6f907c h1:xQD4Be1l6BRhnP5z9bME30rAIlUL5fRz0R6GJ6iKk8E=
+github.com/df-mc/go-nethernet v1.0.20-0.20260818142457-6fc1eb6f907c/go.mod h1:11MfQo5F7PDKfHg1H0zM5mMkrCv29jRE0lK5B4egW9w=
 github.com/df-mc/go-nethernet v1.0.20 h1:H0MO0GkVlAypu9IDQhzg5Pph3mCD7r40+ExiImsXT2M=
 github.com/df-mc/go-nethernet v1.0.20/go.mod h1:11MfQo5F7PDKfHg1H0zM5mMkrCv29jRE0lK5B4egW9w=
 github.com/df-mc/go-playfab/v2 v2.0.2 h1:JqOsrpe0nt6Ni4V2JrdmOAhbBgTm7LBw1ppGXlmknhs=

--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -838,33 +838,6 @@ func (conn *Conn) handleLogin(pk *packet.Login) error {
 		return fmt.Errorf("parse login request: %w", err)
 	}
 
-	// TODO: Mojang bumped the protocol without changing the protocol version number in 1.26.44,
-	// so we need to check the game version to determine whether we need to downgrade the protocol.
-	// This is a temporary workaround until the protocol version is properly bumped in a future release.
-	var majorVer, minorVer, patchVer int
-	_, _ = fmt.Sscanf(conn.clientData.GameVersion, "%d.%d.%d", &majorVer, &minorVer, &patchVer)
-	if majorVer == 1 && minorVer == 26 && patchVer < 44 {
-		// Check if one of the accepted protocols matches the client's protocol version, such as
-		// 1.26.43, 1.26.42, 1.26.41, or 1.26.40. If a matching protocol is found, use it instead
-		// of the current protocol.
-		for _, pro := range conn.acceptedProto {
-			if pro.ID() == protocol.CurrentProtocol {
-				var majorVer, minorVer, patchVer int
-				_, _ = fmt.Sscanf(pro.Ver(), "%d.%d.%d", &majorVer, &minorVer, &patchVer)
-				if majorVer == 1 && minorVer == 26 && patchVer < 44 {
-					conn.proto = pro
-					conn.pool = pro.Packets(true)
-					break
-				}
-			}
-		}
-
-		if conn.proto.Ver() == protocol.CurrentVersion {
-			_ = conn.WritePacket(&packet.PlayStatus{Status: packet.PlayStatusLoginFailedClient})
-			return fmt.Errorf("incompatible protocol game version: expected %s, got %s", protocol.CurrentVersion, conn.clientData.GameVersion)
-		}
-	}
-
 	// Make sure the player is logged in with XBOX Live when necessary.
 	if !authResult.XBOXLiveAuthenticated && conn.authEnabled {
 		_ = conn.WritePacket(&packet.Disconnect{Message: text.Colourf("<red>You must be logged in with XBOX Live to join.</red>")})

--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -17,6 +17,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -450,9 +451,23 @@ var skinResourcePatch []byte
 //go:embed skin_geometry.json
 var skinGeometry []byte
 
+// serverAddress returns the address in the form clients report it in their login request. For
+// networks addressed by a URL, such as NetherNet, clients repeat the port of the address after
+// it: 'https://<host>:<port>:<port>'.
+func serverAddress(address string) string {
+	if !strings.Contains(address, "://") {
+		return address
+	}
+	u, err := url.Parse(address)
+	if err != nil || u.Port() == "" {
+		return address
+	}
+	return address + ":" + u.Port()
+}
+
 // defaultClientData edits the ClientData passed to have defaults set to all fields that were left unchanged.
 func defaultClientData(address, username string, d *login.ClientData) {
-	d.ServerAddress = address
+	d.ServerAddress = serverAddress(address)
 	d.ThirdPartyName = username
 	if d.DeviceOS == 0 {
 		d.DeviceOS = protocol.DeviceAndroid

--- a/minecraft/nethernet.go
+++ b/minecraft/nethernet.go
@@ -50,6 +50,7 @@ func (n NetherNet) DialContextIdentity(ctx context.Context, address string, toke
 		n.Dialer.Identity = &nethernet.Identity{
 			PrivateKey: privateKey,
 			Token:      token,
+			Domain:     "self",
 		}
 	}
 	return n.DialContext(ctx, address)

--- a/minecraft/nethernet.go
+++ b/minecraft/nethernet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 
@@ -47,10 +48,15 @@ func (n NetherNet) DialContext(ctx context.Context, address string) (net.Conn, e
 // If [nethernet.Dialer.Identity] is already set, that identity is used instead.
 func (n NetherNet) DialContextIdentity(ctx context.Context, address string, token string, privateKey *ecdsa.PrivateKey) (net.Conn, error) {
 	if n.Dialer.Identity == nil {
+		env, err := authEnv(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("request authorization environment: %w", err)
+		}
 		n.Dialer.Identity = &nethernet.Identity{
 			PrivateKey: privateKey,
 			Token:      token,
-			Domain:     "self",
+			// We need to append '/' on the URL if not present.
+			Domain: env.Issuer.JoinPath().String(),
 		}
 	}
 	return n.DialContext(ctx, address)

--- a/minecraft/protocol/attribute_layer.go
+++ b/minecraft/protocol/attribute_layer.go
@@ -84,6 +84,24 @@ func (x *AttributeData) Marshal(r IO) {
 	}
 }
 
+const (
+	NoiseAlignmentTypeMinLocalTransitionEnd = iota
+)
+
+// NoiseAlignment represents the way the noise of an environment attribute transition is aligned.
+type NoiseAlignment struct {
+	// Type is the type of the alignment. It is one of the NoiseAlignmentType constants above.
+	Type byte
+	// Value is the value that the noise is aligned against, the meaning of which depends on Type.
+	Value uint32
+}
+
+// Marshal encodes/decodes a NoiseAlignment.
+func (x *NoiseAlignment) Marshal(r IO) {
+	r.Uint8(&x.Type)
+	r.Varuint32(&x.Value)
+}
+
 // EnvironmentAttributeData represents an environment attribute with optional transition data.
 type EnvironmentAttributeData struct {
 	// AttributeName is the name of the attribute.
@@ -104,6 +122,8 @@ type EnvironmentAttributeData struct {
 	LocalTransitionTicks uint32
 	// NoiseTransition indicates whether the transition uses noise.
 	NoiseTransition bool
+	// NoiseAlignment is the alignment of the noise used by the transition.
+	NoiseAlignment NoiseAlignment
 }
 
 // Marshal encodes/decodes an EnvironmentAttributeData.
@@ -119,6 +139,7 @@ func (x *EnvironmentAttributeData) Marshal(r IO) {
 	easingTypeFromString(r, &x.EaseType, easingType)
 	r.Uint32(&x.LocalTransitionTicks)
 	r.Bool(&x.NoiseTransition)
+	Single(r, &x.NoiseAlignment)
 }
 
 // AttributeLayerSettings represents settings for an attribute layer.

--- a/minecraft/protocol/camera.go
+++ b/minecraft/protocol/camera.go
@@ -383,6 +383,11 @@ type CameraPreset struct {
 	//  - ControlSchemePlayerRelativeStrafe makes movement the same as the default behaviour, but can be
 	//    used in a custom camera.
 	ControlScheme Optional[byte]
+	// ApplyInheritedStartingRotation specifies if the camera should start at the rotation of the preset it
+	// inherits from, rather than at StartingRotation.
+	ApplyInheritedStartingRotation bool
+	// StartingRotation is the rotation that the camera starts at when the preset is applied.
+	StartingRotation Optional[mgl32.Vec2]
 }
 
 // Marshal encodes/decodes a CameraPreset.
@@ -409,6 +414,8 @@ func (x *CameraPreset) Marshal(r IO) {
 	OptionalFunc(r, &x.PlayerEffects, r.Bool)
 	OptionalMarshaler(r, &x.AimAssist)
 	OptionalFunc(r, &x.ControlScheme, r.Uint8)
+	r.Bool(&x.ApplyInheritedStartingRotation)
+	OptionalFunc(r, &x.StartingRotation, r.Vec2)
 }
 
 // CameraPresetAimAssist represents a preset for aim assist settings.

--- a/minecraft/protocol/furnace.go
+++ b/minecraft/protocol/furnace.go
@@ -1,0 +1,34 @@
+package protocol
+
+const (
+	FurnaceLayoutNone = iota
+	FurnaceLayoutInventoryOnly
+	FurnaceLayoutDefault
+)
+
+const (
+	FurnaceLeftTabNone = iota
+	FurnaceLeftTabRecipeFood
+	FurnaceLeftTabRecipeItems
+	FurnaceLeftTabRecipeBlocks
+	FurnaceLeftTabRecipeSearch
+	FurnaceLeftTabInventory
+)
+
+// FurnaceOptions holds the options that a player has selected in a furnace-like container's UI.
+type FurnaceOptions struct {
+	// LeftFurnaceTab is the tab that is selected on the left side of the furnace UI. It is one of the
+	// FurnaceLeftTab constants above.
+	LeftFurnaceTab int32
+	// Filtering is whether the player has enabled the filtering between recipes they have unlocked or not.
+	Filtering bool
+	// Layout is the layout of the furnace UI. It is one of the FurnaceLayout constants above.
+	Layout int32
+}
+
+// Marshal encodes/decodes a FurnaceOptions.
+func (x *FurnaceOptions) Marshal(r IO) {
+	r.Varint32(&x.LeftFurnaceTab)
+	r.Bool(&x.Filtering)
+	r.Varint32(&x.Layout)
+}

--- a/minecraft/protocol/info.go
+++ b/minecraft/protocol/info.go
@@ -2,7 +2,7 @@ package protocol
 
 const (
 	// CurrentProtocol is the current protocol version for the version below.
-	CurrentProtocol = 2168
+	CurrentProtocol = 2192
 	// CurrentVersion is the current version of Minecraft as supported by the `packet` package.
-	CurrentVersion = "1.26.44"
+	CurrentVersion = "1.26.50"
 )

--- a/minecraft/protocol/input_flags.go
+++ b/minecraft/protocol/input_flags.go
@@ -5,8 +5,8 @@ import "slices"
 // InputFlags is the set of input flags in a PlayerAuthInput packet. It is sent as a list of the IDs of the
 // flags that are set, and is stored the same way, with the IDs kept unique.
 //
-// An absent InputFlags is not the same as an empty one: it is not sent at all. The zero value is absent and
-// has no size, so use NewInputFlags before setting a flag on it. Decoded values are always sized.
+// The zero value has no size, so use NewInputFlags before setting a flag on it. Decoded values are always
+// sized.
 type InputFlags struct {
 	set  bool
 	size int
@@ -27,7 +27,8 @@ func NewInputFlagsFromIDs(size int, ids []int32) InputFlags {
 	return flags
 }
 
-// Present returns whether the InputFlags was sent. An absent one reports every flag as unset.
+// Present returns whether the InputFlags holds any flags. A value that is not present reports every flag as
+// unset.
 func (f InputFlags) Present() bool {
 	return f.set
 }
@@ -76,13 +77,6 @@ func (f InputFlags) check(i int) {
 // InputFlagList reads/writes an InputFlags holding flags in the range [0, size) as a list of the IDs of the
 // flags that are set. Flag IDs must be unique and within range.
 func InputFlagList(r IO, x *InputFlags, size int) {
-	present := x.set
-	r.Bool(&present)
-	if !present {
-		*x = InputFlags{size: size}
-		return
-	}
-
 	// Check the count before reading, so a peer cannot claim far more flags than can legally be sent.
 	count := uint32(len(x.ids))
 	r.Varuint32(&count)

--- a/minecraft/protocol/inventory.go
+++ b/minecraft/protocol/inventory.go
@@ -43,8 +43,8 @@ type InventoryAction struct {
 // Marshal encodes/decodes an InventoryAction.
 func (x *InventoryAction) Marshal(r IO) {
 	r.Varuint32(&x.SourceType)
-	DoubleOptionalFunc(r, &x.WindowID, r.Int8)
-	DoubleOptionalFunc(r, &x.SourceFlags, r.Varuint32)
+	OptionalFunc(r, &x.WindowID, r.Int8)
+	OptionalFunc(r, &x.SourceFlags, r.Varuint32)
 	r.Varuint32(&x.InventorySlot)
 	r.ItemInstance(&x.OldItem)
 	r.ItemInstance(&x.NewItem)
@@ -133,6 +133,11 @@ const (
 	ClientCooldownStateOn
 )
 
+const (
+	HandSlotMainHand = iota
+	HandSlotOffHand
+)
+
 // UseItemTransactionData represents an inventory transaction data object sent when the client uses an item on
 // a block.
 type UseItemTransactionData struct {
@@ -151,7 +156,7 @@ type UseItemTransactionData struct {
 	// these actions hold one slot in which one item was changed to another. In general, the combination of
 	// all of these actions results in a balanced inventory transaction. This should be checked to ensure that
 	// no items are cheated into the inventory.
-	Actions Optional[[]InventoryAction]
+	Actions []InventoryAction
 	// ActionType is the type of the UseItem inventory transaction. It is one of the action types found above,
 	// and specifies the way the player interacted with the block.
 	ActionType uint32
@@ -169,6 +174,9 @@ type UseItemTransactionData struct {
 	// HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
 	// to ensure that the hot bar slot and held item are correctly synchronised with the server.
 	HotBarSlot int32
+	// Hand is the hand that the player used to interact with the block. It is one of the HandSlot constants
+	// above.
+	Hand byte
 	// HeldItem is the item that was held to interact with the block. The server should check if this item
 	// is actually present in the HotBarSlot.
 	HeldItem ItemInstance
@@ -247,6 +255,7 @@ func (data *UseItemTransactionData) Marshal(r IO) {
 	r.BlockPos(&data.BlockPosition)
 	IntegerFunc(&data.BlockFace, r.Uint8)
 	r.Varint32(&data.HotBarSlot)
+	r.Uint8(&data.Hand)
 	r.ItemInstance(&data.HeldItem)
 	r.Vec3(&data.Position)
 	r.Vec3(&data.ClickedPosition)

--- a/minecraft/protocol/io.go
+++ b/minecraft/protocol/io.go
@@ -206,17 +206,6 @@ func OptionalFunc[T any](r IO, x *Optional[T], f func(*T)) any {
 	return x
 }
 
-// DoubleOptionalFunc reads/writes an Optional[T] nested inside an always-present outer optional.
-func DoubleOptionalFunc[T any](r IO, x *Optional[T], f func(*T)) {
-	outer := true
-	r.Bool(&outer)
-	if outer {
-		OptionalFunc(r, x, f)
-	} else {
-		*x = Optional[T]{}
-	}
-}
-
 // OptionalMarshaler reads/writes an Optional assuming *T implements Marshaler.
 func OptionalMarshaler[T any, A PtrMarshaler[T]](r IO, x *Optional[T]) {
 	r.Bool(&x.set)

--- a/minecraft/protocol/item_stack.go
+++ b/minecraft/protocol/item_stack.go
@@ -235,7 +235,7 @@ func (x *ItemStackResponse) Marshal(r IO) {
 	if len(x.ContainerInfo) != 0 {
 		containerInfo = Option(x.ContainerInfo)
 	}
-	DoubleOptionalFunc(r, &containerInfo, func(containerInfo *[]StackResponseContainerInfo) {
+	OptionalFunc(r, &containerInfo, func(containerInfo *[]StackResponseContainerInfo) {
 		Slice(r, containerInfo)
 	})
 	if value, ok := containerInfo.Value(); ok {
@@ -288,7 +288,7 @@ func (x *StackResponseSlotInfo) Marshal(r IO) {
 	if x.StackNetworkID > 0 {
 		stackNetworkID = Option(x.StackNetworkID)
 	}
-	DoubleOptionalFunc(r, &stackNetworkID, r.Varint32)
+	OptionalFunc(r, &stackNetworkID, r.Varint32)
 	if value, ok := stackNetworkID.Value(); ok {
 		x.StackNetworkID = value
 	}

--- a/minecraft/protocol/map.go
+++ b/minecraft/protocol/map.go
@@ -29,6 +29,12 @@ const (
 	MapDecorationTypeVillageTaiga
 	MapDecorationTypeJungleTemple
 	MapDecorationTypeWitchHut
+	MapDecorationTypeTrialChambers
+	MapDecorationTypeAbandonedCamp
+	MapDecorationTypeBuriedAncientCity
+	MapDecorationTypeBuriedMineshaft
+	MapDecorationTypeDesertPyramid
+	MapDecorationTypeWarmOceanRuins
 )
 
 const (

--- a/minecraft/protocol/memory_category.go
+++ b/minecraft/protocol/memory_category.go
@@ -1,5 +1,9 @@
 package protocol
 
+import (
+	"github.com/go-gl/mathgl/mgl32"
+)
+
 const (
 	MemoryCategoryUnknown = iota
 	MemoryCategoryInvalidSizeUnknown
@@ -59,7 +63,6 @@ const (
 	MemoryCategoryOreUIClient
 	MemoryCategoryPersonaPieces
 	MemoryCategoryPersonaAnimations
-	MemoryCategoryPersonaTextures
 	MemoryCategoryPersonaCharacters
 	MemoryCategoryPersonaSkinPacks
 	MemoryCategoryPersonaRepo
@@ -139,6 +142,10 @@ type EntityDiagnosticTimingInfo struct {
 	DurationNanos uint64
 	// PercentOfTotal is the percentage of time that this timing entry has used compared to others.
 	PercentOfTotal byte
+	// Position is the position of the entity that is being timed.
+	Position mgl32.Vec3
+	// Dimension is the name of the dimension that the entity being timed is in.
+	Dimension string
 }
 
 // Marshal encodes/decodes a EntityDiagnosticTimingInfo.
@@ -147,6 +154,8 @@ func (x *EntityDiagnosticTimingInfo) Marshal(r IO) {
 	r.String(&x.Entity)
 	r.Uint64(&x.DurationNanos)
 	r.Uint8(&x.PercentOfTotal)
+	r.Vec3(&x.Position)
+	r.String(&x.Dimension)
 }
 
 // SystemDiagnosticTimingInfo represents diagnostics for a specific system index.

--- a/minecraft/protocol/packet/boss_event.go
+++ b/minecraft/protocol/packet/boss_event.go
@@ -45,9 +45,6 @@ type BossEvent struct {
 	// BossEntityUniqueID is the same as the client's entity unique ID, its
 	// HealthPercentage and BossBarTitle can be freely altered.
 	BossEntityUniqueID int64
-	// PlayerUniqueID is the unique ID of the player that is registered to or
-	// unregistered from the boss fight.
-	PlayerUniqueID int64
 	// EventType is the type of the event. It is one of the BossEvent constants above.
 	EventType uint8
 	// BossBarTitle is the title shown above the boss bar. It may be set to set
@@ -78,7 +75,6 @@ func (*BossEvent) ID() uint32 {
 
 func (pk *BossEvent) Marshal(io protocol.IO) {
 	io.ActorUniqueID(&pk.BossEntityUniqueID)
-	io.ActorUniqueID(&pk.PlayerUniqueID)
 	io.Uint8(&pk.EventType)
 	io.String(&pk.BossBarTitle)
 	io.String(&pk.FilteredBossBarTitle)

--- a/minecraft/protocol/packet/disconnect.go
+++ b/minecraft/protocol/packet/disconnect.go
@@ -145,6 +145,16 @@ const (
 	DisconnectReasonNonceNotFound
 	DisconnectReasonNonceExpired
 	DisconnectReasonNonceNotValid
+	DisconnectReasonHostDisconnected
+	DisconnectReasonEditorJoinIntentPolicyFailure
+	DisconnectReasonNetherNetIdentityNotAllowed
+	DisconnectReasonInvalidName
+	DisconnectReasonExpiredToken
+	DisconnectReasonHostAcceptsNoTypeOfAuth
+	DisconnectReasonNotAuthenticatedFastFail
+	DisconnectReasonEditorNotAllowed
+	DisconnectReasonMissingStructureData
+	DisconnectReasonUnsupportedTransport
 )
 
 // Disconnect may be sent by the server to disconnect the client using an optional message to send as the

--- a/minecraft/protocol/packet/id.go
+++ b/minecraft/protocol/packet/id.go
@@ -251,4 +251,6 @@ const (
 	IDClientboundUpdateSoundData
 	IDSendPartyDestinationCookie
 	IDPartyDestinationCookieResponse
+	IDSetPlayerFurnaceOptions
+	IDRecordStarted
 )

--- a/minecraft/protocol/packet/inventory_transaction.go
+++ b/minecraft/protocol/packet/inventory_transaction.go
@@ -52,17 +52,7 @@ func (pk *InventoryTransaction) Marshal(io protocol.IO) {
 	if hasLegacy {
 		protocol.Slice(io, &pk.LegacySetItemSlots)
 	}
-	hasType := true
-	io.Bool(&hasType)
-	if !hasType {
-		io.InvalidValue(hasType, "InventoryTransaction transaction type", "expected presence bool to be true")
-	}
 	io.TransactionDataType(&pk.TransactionData)
-	hasActions := true
-	io.Bool(&hasActions)
-	if !hasActions {
-		io.InvalidValue(hasActions, "InventoryTransaction actions", "expected presence bool to be true")
-	}
 	protocol.Slice(io, &pk.Actions)
 	pk.TransactionData.Marshal(io)
 }

--- a/minecraft/protocol/packet/move_actor_delta.go
+++ b/minecraft/protocol/packet/move_actor_delta.go
@@ -30,6 +30,8 @@ type MoveActorDelta struct {
 	// ForceCompletion specifies whether the client should complete any in-progress local movement before applying the
 	// update.
 	ForceCompletion bool
+	// Ticks is the number of ticks over which the movement should be interpolated by the client.
+	Ticks uint64
 }
 
 // ID ...
@@ -49,4 +51,5 @@ func (pk *MoveActorDelta) Marshal(io protocol.IO) {
 	io.Bool(&pk.ForceMove)
 	io.Bool(&pk.ForceMoveLocalEntity)
 	io.Bool(&pk.ForceCompletion)
+	io.Varuint64(&pk.Ticks)
 }

--- a/minecraft/protocol/packet/play_sound.go
+++ b/minecraft/protocol/packet/play_sound.go
@@ -22,9 +22,15 @@ type PlaySound struct {
 	Pitch float32
 	// LoopCount is the number of times to loop the sound before stopping. -1 means no looping at all.
 	LoopCount int32
+	// BypassListenerRangeCheck specifies if the sound should be played regardless of how far away the player
+	// is from the position of the sound.
+	BypassListenerRangeCheck bool
 	// Handle is an optional sound handle ID. It is currently unknown what this is for, and is not required
 	// to be set by servers.
 	Handle protocol.Optional[uint64]
+	// PlaybackPositionSeconds is an optional offset, in seconds, into the sound at which playback should
+	// start. If not set, the sound is played from the start.
+	PlaybackPositionSeconds protocol.Optional[float32]
 }
 
 // ID ...
@@ -38,5 +44,7 @@ func (pk *PlaySound) Marshal(io protocol.IO) {
 	io.Float32(&pk.Volume)
 	io.Float32(&pk.Pitch)
 	io.Varint32(&pk.LoopCount)
+	io.Bool(&pk.BypassListenerRangeCheck)
 	protocol.OptionalFunc(io, &pk.Handle, io.Uint64)
+	protocol.OptionalFunc(io, &pk.PlaybackPositionSeconds, io.Float32)
 }

--- a/minecraft/protocol/packet/player_auth_input.go
+++ b/minecraft/protocol/packet/player_auth_input.go
@@ -183,15 +183,15 @@ func (pk *PlayerAuthInput) Marshal(io protocol.IO) {
 	io.Float32(&pk.InteractYaw)
 	io.Varuint64(&pk.Tick)
 	io.Vec3(&pk.Delta)
-	protocol.DoubleOptionalFunc(io, &pk.ItemInteractionData, io.PlayerInventoryAction)
-	protocol.DoubleOptionalFunc(io, &pk.ItemStackRequest, func(x *protocol.ItemStackRequest) {
+	protocol.OptionalFunc(io, &pk.ItemInteractionData, io.PlayerInventoryAction)
+	protocol.OptionalFunc(io, &pk.ItemStackRequest, func(x *protocol.ItemStackRequest) {
 		x.Marshal(io)
 	})
-	protocol.DoubleOptionalFunc(io, &pk.BlockActions, func(x *[]protocol.PlayerBlockAction) {
+	protocol.OptionalFunc(io, &pk.BlockActions, func(x *[]protocol.PlayerBlockAction) {
 		protocol.Slice(io, x)
 	})
-	protocol.DoubleOptionalFunc(io, &pk.VehicleRotation, io.Vec2)
-	protocol.DoubleOptionalFunc(io, &pk.ClientPredictedVehicle, io.ActorUniqueID)
+	protocol.OptionalFunc(io, &pk.VehicleRotation, io.Vec2)
+	protocol.OptionalFunc(io, &pk.ClientPredictedVehicle, io.ActorUniqueID)
 	io.Vec2(&pk.AnalogueMoveVector)
 	io.Vec3(&pk.CameraOrientation)
 	io.Vec2(&pk.RawMoveVector)

--- a/minecraft/protocol/packet/pool.go
+++ b/minecraft/protocol/packet/pool.go
@@ -285,6 +285,8 @@ func init() {
 		IDServerPresenceInfo:                 func() Packet { return &ServerPresenceInfo{} },
 		IDClientboundUpdateSoundData:         func() Packet { return &ClientboundUpdateSoundData{} },
 		IDSendPartyDestinationCookie:         func() Packet { return &SendPartyDestinationCookie{} },
+		IDSetPlayerFurnaceOptions:            func() Packet { return &SetPlayerFurnaceOptions{} },
+		IDRecordStarted:                      func() Packet { return &RecordStarted{} },
 	}
 	for id, pk := range serverOriginating {
 		RegisterPacketFromServer(id, pk)
@@ -380,6 +382,7 @@ func init() {
 		IDPartyChanged:                      func() Packet { return &PartyChanged{} },
 		IDServerBoundDataDrivenScreenClosed: func() Packet { return &ServerBoundDataDrivenScreenClosed{} },
 		IDPartyDestinationCookieResponse:    func() Packet { return &PartyDestinationCookieResponse{} },
+		IDSetPlayerFurnaceOptions:           func() Packet { return &SetPlayerFurnaceOptions{} },
 	}
 	for id, pk := range clientOriginating {
 		RegisterPacketFromClient(id, pk)

--- a/minecraft/protocol/packet/record_started.go
+++ b/minecraft/protocol/packet/record_started.go
@@ -1,0 +1,25 @@
+package packet
+
+import (
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+)
+
+// RecordStarted is sent by the server to notify the client that a record started playing at a specific block
+// position, such as when a music disc is inserted into a jukebox.
+type RecordStarted struct {
+	// Position is the position of the block that the record started playing at.
+	Position protocol.BlockPos
+	// Handle is the server-side handle of the sound that the record is played through. It may be used in the
+	// ClientboundUpdateSoundData packet to update the sound afterwards.
+	Handle uint64
+}
+
+// ID ...
+func (*RecordStarted) ID() uint32 {
+	return IDRecordStarted
+}
+
+func (pk *RecordStarted) Marshal(io protocol.IO) {
+	io.BlockPos(&pk.Position)
+	io.Uint64(&pk.Handle)
+}

--- a/minecraft/protocol/packet/set_player_furnace_options.go
+++ b/minecraft/protocol/packet/set_player_furnace_options.go
@@ -1,0 +1,32 @@
+package packet
+
+import (
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+)
+
+const (
+	FurnaceTypeNone = iota
+	FurnaceTypeFurnace
+	FurnaceTypeBlastFurnace
+	FurnaceTypeSmoker
+)
+
+// SetPlayerFurnaceOptions is a bidirectional packet that can be used to update the options a player has
+// selected in a furnace-like container's UI.
+type SetPlayerFurnaceOptions struct {
+	// FurnaceType is the type of furnace that the options apply to. It is one of the FurnaceType constants
+	// above.
+	FurnaceType byte
+	// FurnaceOptions holds the options that the player has selected for the furnace type above.
+	FurnaceOptions protocol.FurnaceOptions
+}
+
+// ID ...
+func (*SetPlayerFurnaceOptions) ID() uint32 {
+	return IDSetPlayerFurnaceOptions
+}
+
+func (pk *SetPlayerFurnaceOptions) Marshal(io protocol.IO) {
+	io.Uint8(&pk.FurnaceType)
+	protocol.Single(io, &pk.FurnaceOptions)
+}

--- a/minecraft/protocol/player.go
+++ b/minecraft/protocol/player.go
@@ -37,7 +37,7 @@ const (
 	PlayerActionStopSwimming
 	PlayerActionStartSpinAttack
 	PlayerActionStopSpinAttack
-	PlayerActionStartBuildingBlock
+	PlayerActionInteractWithBlock
 	PlayerActionPredictDestroyBlock
 	PlayerActionContinueDestroyBlock
 	PlayerActionStartItemUseOn

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"bytes"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"image/color"

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"image/color"
@@ -245,9 +246,7 @@ func (r *Reader) PlayerInventoryAction(x *UseItemTransactionData) {
 	OptionalFunc(r, &x.LegacySetItemSlots, func(slots *[]LegacySetItemSlot) {
 		Slice(r, slots)
 	})
-	DoubleOptionalFunc(r, &x.Actions, func(actions *[]InventoryAction) {
-		Slice(r, actions)
-	})
+	Slice(r, &x.Actions)
 	IntegerFunc(&x.ActionType, r.Varint32)
 	IntegerFunc(&x.TriggerType, r.Uint8)
 	r.BlockPos(&x.BlockPosition)
@@ -587,6 +586,10 @@ func (r *Reader) PackSetting(x *PackSetting) {
 	case PackSettingTypeString:
 		var v string
 		r.String(&v)
+		x.Value = v
+	case PackSettingTypeStringList:
+		var v []string
+		FuncSlice(r, &v, r.String)
 		x.Value = v
 	default:
 		r.UnknownEnumOption(t, "pack setting")

--- a/minecraft/protocol/resource_pack.go
+++ b/minecraft/protocol/resource_pack.go
@@ -6,6 +6,7 @@ const (
 	PackSettingTypeFloat = iota
 	PackSettingTypeBool
 	PackSettingTypeString
+	PackSettingTypeStringList
 )
 
 // TexturePackInfo represents a texture pack's info sent over network. It holds information about the
@@ -98,6 +99,6 @@ func (x *PackURL) Marshal(r IO) {
 type PackSetting struct {
 	// Name is the name of the pack setting.
 	Name string
-	// Value is the new value of the setting. This is either a float32, bool or string.
+	// Value is the new value of the setting. This is either a float32, bool, string or []string.
 	Value any
 }

--- a/minecraft/protocol/scoreboard.go
+++ b/minecraft/protocol/scoreboard.go
@@ -55,7 +55,7 @@ func (x *ScoreboardEntry) Marshal(r IO) {
 		if x.ObjectiveName != "" {
 			objective = Option(x.ObjectiveName)
 		}
-		DoubleOptionalFunc(r, &objective, r.String)
+		OptionalFunc(r, &objective, r.String)
 		x.ObjectiveName, _ = objective.Value()
 	case ScoreboardIdentityEntity, ScoreboardIdentityPlayer:
 		r.String(&x.ObjectiveName)

--- a/minecraft/protocol/shape.go
+++ b/minecraft/protocol/shape.go
@@ -112,6 +112,9 @@ type TextShape struct {
 	UseRotation bool
 	// BackgroundColour is the RGBA colour to use for the text background. This is a translucent black colour by default.
 	BackgroundColour Optional[color.RGBA]
+	// LineGapHeight is the gap to leave between each line of multiline text. If not set, the client uses its
+	// default gap.
+	LineGapHeight Optional[float32]
 	// DepthTest is whether the text should show through walls. Use true for default behaviour.
 	DepthTest bool
 	// ShowBackface is if the background should render on the back side of the shape. This only has a visible effect when
@@ -127,6 +130,7 @@ func (shape *TextShape) Marshal(io IO) {
 	io.String(&shape.Text)
 	io.Bool(&shape.UseRotation)
 	OptionalFunc(io, &shape.BackgroundColour, io.BEARGB)
+	OptionalFunc(io, &shape.LineGapHeight, io.Float32)
 	io.Bool(&shape.DepthTest)
 	io.Bool(&shape.ShowBackface)
 	io.Bool(&shape.ShowBackfaceText)

--- a/minecraft/protocol/sub_chunk.go
+++ b/minecraft/protocol/sub_chunk.go
@@ -46,11 +46,11 @@ func (x *SubChunkEntry) Marshal(r IO) {
 	OptionalFunc(r, &x.RawPayload, r.ByteSlice)
 	r.Uint8(&x.HeightMapType)
 	OptionalFunc(r, &x.HeightMapData, func(data *[]int8) {
-		FuncSliceOfLen(r, 256, data, r.Int8)
+		FuncSliceOfLen(r, 272, data, r.Int8)
 	})
 	r.Uint8(&x.RenderHeightMapType)
 	OptionalFunc(r, &x.RenderHeightMapData, func(data *[]int8) {
-		FuncSliceOfLen(r, 256, data, r.Int8)
+		FuncSliceOfLen(r, 272, data, r.Int8)
 	})
 	OptionalFunc(r, &x.BlobHash, r.Uint64)
 }

--- a/minecraft/protocol/world.go
+++ b/minecraft/protocol/world.go
@@ -16,8 +16,11 @@ const (
 type DimensionDefinition struct {
 	// Name specifies the name of the dimension.
 	Name string
-	// Range is the height range of the dimension, where the first value is the exclusive maximum and the second is the inclusive minimum.
-	Range [2]int32
+	// MinimumY is the lowest Y coordinate that exists in the dimension.
+	MinimumY int32
+	// HeightRange is the number of blocks above MinimumY that exist in the dimension, so that the highest Y
+	// coordinate in the dimension is MinimumY + HeightRange.
+	HeightRange int32
 	// Generator is the variant of generator that exists in the provided dimension. These can be one of the constants
 	// defined above. If this is set to GeneratorLegacy, the legacy horizontal world limits will be enforced.
 	Generator int32
@@ -26,16 +29,19 @@ type DimensionDefinition struct {
 	DimensionType int32
 	// PackID is the UUID of the behaviour pack which has added the dimension.
 	PackID uuid.UUID
+	// DefaultBiome is the identifier of the biome that the dimension defaults to.
+	DefaultBiome string
 }
 
 // Marshal encodes/decodes a DimensionDefinition.
 func (x *DimensionDefinition) Marshal(r IO) {
 	r.String(&x.Name)
-	r.Varint32(&x.Range[0])
-	r.Varint32(&x.Range[1])
+	r.Varint32(&x.MinimumY)
+	r.Varint32(&x.HeightRange)
 	r.Varint32(&x.Generator)
 	r.Varint32(&x.DimensionType)
 	r.UUID(&x.PackID)
+	r.String(&x.DefaultBiome)
 }
 
 // GenerationFeature represents a world generation feature, used when encoding the FeatureRegistry to the client.

--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -183,9 +183,7 @@ func (w *Writer) PlayerInventoryAction(x *UseItemTransactionData) {
 	OptionalFunc(w, &x.LegacySetItemSlots, func(slots *[]LegacySetItemSlot) {
 		Slice(w, slots)
 	})
-	DoubleOptionalFunc(w, &x.Actions, func(actions *[]InventoryAction) {
-		Slice(w, actions)
-	})
+	Slice(w, &x.Actions)
 	IntegerFunc(&x.ActionType, w.Varint32)
 	IntegerFunc(&x.TriggerType, w.Uint8)
 	w.BlockPos(&x.BlockPosition)
@@ -494,6 +492,10 @@ func (w *Writer) PackSetting(x *PackSetting) {
 		id = PackSettingTypeString
 		w.Varuint32(&id)
 		w.String(&val)
+	case []string:
+		id = PackSettingTypeStringList
+		w.Varuint32(&id)
+		FuncSlice(w, &val, w.String)
 	default:
 		w.UnknownEnumOption(x.Value, "pack setting")
 	}


### PR DESCRIPTION
to match the vanilla client behavior, just in case