### PR TITLE
fix: harden connection close and protocol reads

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -517,6 +517,9 @@ func (conn *Conn) Read(b []byte) (n int, err error) {
 // Flush flushes the packets currently buffered by the connections to the underlying net.Conn, so that they
 // are directly sent.
 func (conn *Conn) Flush() error {
+	if conn.ctx == nil {
+		return net.ErrClosed
+	}
 	select {
 	case <-conn.ctx.Done():
 		return conn.closeErr("flush")
@@ -1636,8 +1639,12 @@ func (conn *Conn) close(cause error) error {
 	var err error
 	conn.once.Do(func() {
 		err = conn.Flush()
-		conn.cancelFunc(cause)
-		_ = conn.conn.Close()
+		if conn.cancelFunc != nil {
+			conn.cancelFunc(cause)
+		}
+		if conn.conn != nil {
+			_ = conn.conn.Close()
+		}
 	})
 	return err
 }

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -75,7 +75,7 @@ func (r *Reader) StringUTF(x *string) {
 	}
 	r.checkRemaining(l, "string")
 	data := make([]byte, l)
-	if _, err := r.r.Read(data); err != nil {
+	if _, err := io.ReadFull(r.r, data); err != nil {
 		r.panic(err)
 	}
 	*x = *(*string)(unsafe.Pointer(&data))
@@ -91,7 +91,7 @@ func (r *Reader) String(x *string) {
 	}
 	r.checkRemaining(l, "string")
 	data := make([]byte, l)
-	if _, err := r.r.Read(data); err != nil {
+	if _, err := io.ReadFull(r.r, data); err != nil {
 		r.panic(err)
 	}
 	*x = *(*string)(unsafe.Pointer(&data))
@@ -107,7 +107,7 @@ func (r *Reader) ByteSlice(x *[]byte) {
 	}
 	r.checkRemaining(l, "byte slice")
 	data := make([]byte, l)
-	if _, err := r.r.Read(data); err != nil {
+	if _, err := io.ReadFull(r.r, data); err != nil {
 		r.panic(err)
 	}
 	*x = data


### PR DESCRIPTION
## What changed

- avoid nil dereferences when closing a partially initialized connection
- use `io.ReadFull` for length-prefixed strings and byte slices so empty terminal values and partial reads are handled correctly