### PR TITLE
protocol/item_stack.go: Fix FilteredCustomName encoding

### DIFF
--- a/minecraft/protocol/item_stack.go
+++ b/minecraft/protocol/item_stack.go
@@ -272,8 +272,8 @@ type StackResponseSlotInfo struct {
 	// CustomName is the custom name of the item stack. It is used in relation to text filtering.
 	CustomName string
 	// FilteredCustomName is a filtered version of CustomName with all the profanity removed. The client will
-	// use this over CustomName if this field is not empty and they have the "Filter Profanity" setting enabled.
-	FilteredCustomName string
+	// use this over CustomName if present and they have the "Filter Profanity" setting enabled.
+	FilteredCustomName Optional[string]
 	// DurabilityCorrection is the current durability of the item stack. This durability will be shown
 	// client-side after the response is sent to the client.
 	DurabilityCorrection int32
@@ -293,7 +293,7 @@ func (x *StackResponseSlotInfo) Marshal(r IO) {
 		x.StackNetworkID = value
 	}
 	r.String(&x.CustomName)
-	r.String(&x.FilteredCustomName)
+	OptionalFunc(r, &x.FilteredCustomName, r.String)
 	r.Varint32(&x.DurabilityCorrection)
 	if x.DurabilityCorrection < -32768 || x.DurabilityCorrection > 32767 {
 		r.InvalidValue(x.DurabilityCorrection, "durability correction", "must fit in an int16")


### PR DESCRIPTION
Mojang represents the second member of the Redacted type as `std::optional<std::string>`

## Source
https://github.com/LiteLDev/LeviLamina/blob/bc5c9e22ba0c6c0969bf841e1c95609448736eda/src/mc/safety/RedactableString.h#L14-L15