### PR TITLE
server_status_provider.go: Add GameType to ServerStatus

### DIFF
--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -364,9 +364,22 @@ func (listener *Listener) PlayerCount() int {
 // server name of the listener, provided the listener isn't currently hijacking the pong of another server.
 func (listener *Listener) updatePongData() {
 	var (
-		s    = listener.status()
-		port uint16
+		s        = listener.status()
+		port     uint16
+		gameType string
 	)
+	switch s.GameType {
+	case 0:
+		gameType = "Survival"
+	case 1:
+		gameType = "Creative"
+	case 2:
+		gameType = "Adventure"
+	default:
+		// We return "Survival" because simply returning invalid strings
+		// like "Unknown" might not be suitable for third-party clients.
+		gameType = "Survival"
+	}
 	if a, ok := listener.Addr().(interface {
 		AddrPort() netip.AddrPort
 	}); ok {
@@ -374,7 +387,7 @@ func (listener *Listener) updatePongData() {
 	}
 	listener.listener.PongData([]byte(fmt.Sprintf("MCPE;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;%v;",
 		s.ServerName, protocol.CurrentProtocol, protocol.CurrentVersion, s.PlayerCount, s.MaxPlayers,
-		listener.listener.ID(), s.ServerSubName, "Creative", 1, port, port, 0, 0,
+		listener.listener.ID(), s.ServerSubName, gameType, s.GameType, port, port, 0, 0,
 	)))
 }
 

--- a/minecraft/server_status_provider.go
+++ b/minecraft/server_status_provider.go
@@ -1,11 +1,13 @@
 package minecraft
 
 import (
-	"github.com/sandertv/go-raknet"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/sandertv/go-raknet"
 )
 
 // ServerStatusProvider represents a type that is able to provide the visual status of a server, in specific
@@ -34,6 +36,9 @@ type ServerStatus struct {
 	// MaxPlayers is the maximum amount of players in the server. If set to 0, MaxPlayers is set to
 	// PlayerCount + 1.
 	MaxPlayers int
+	// GameType is the default game mode configured in the server, as shown in the friend list.
+	// It is 0 for Survival, 1 for Creative, and 2 for Adventure.
+	GameType int
 }
 
 // ListenerStatusProvider is the default ServerStatusProvider of a Listener. It displays a static server name/
@@ -122,7 +127,7 @@ func (f *ForeignStatusProvider) update() {
 // ParsePongData parses the unconnected pong data passed into the relevant fields of a ServerStatus struct.
 func ParsePongData(pong []byte) ServerStatus {
 	frag := splitPong(string(pong))
-	if len(frag) < 7 {
+	if len(frag) < 9 {
 		return ServerStatus{ServerName: "Invalid pong data"}
 	}
 	serverName := frag[1]
@@ -135,10 +140,29 @@ func ParsePongData(pong []byte) ServerStatus {
 	if err != nil {
 		return ServerStatus{ServerName: "Invalid max player count"}
 	}
+	gameType, ok := parseGameType(frag[8])
+	if !ok {
+		return ServerStatus{ServerName: "Invalid game type"}
+	}
 	return ServerStatus{
 		ServerName:    serverName,
 		ServerSubName: serverSubName,
 		PlayerCount:   online,
 		MaxPlayers:    max,
+		GameType:      gameType,
 	}
+}
+
+// parseGameType converts the game type string from the pong data to its int representation.
+// Returns 0 and false if the game type is not valid.
+func parseGameType(v string) (int, bool) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "survival":
+		return 0, true
+	case "creative":
+		return 1, true
+	case "adventure":
+		return 2, true
+	}
+	return 0, false
 }


### PR DESCRIPTION
This PR adds a `GameType` field to `minecraft.ServerStatus`. This allows LAN/P2P implementations to synchronize the game mode advertised on their network with the listener's server status.